### PR TITLE
ops: harden backups and record deployment readiness

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -173,8 +173,11 @@ The script:
 * Runs bounded retry smoke checks against the local backend health endpoint,
   local frontend, and public site.
 * Fails if the public site exposes an `X-Powered-By` response header.
-* Attempts a best-effort rollback to the previous commit if any post-checkout
-  deploy step fails. The original deployment failure still exits nonzero.
+* Attempts a best-effort code rollback to the previous commit if any
+  post-checkout deploy step fails. The original deployment failure still exits
+  nonzero. This rollback does not restore PostgreSQL, R2 objects, or local
+  uploads; use the backup/restore runbook when a failed release may have changed
+  schema or data.
 
 ### Install or Update the Deploy Command
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -40,6 +40,7 @@ application runtime variables and must not be committed.
 | `ALLOW_BACKUP_DRY_RUN` | `ops/scripts/backup-production.sh` | Local validation only | Defaults to `false`. Must be set to `true` with a non-production `BACKUP_ENV` before `BACKUP_DRY_RUN=true` is accepted. Never set this in `/etc/munich-weekly/backup.env`. |
 | `ALLOW_INCOMPLETE_R2_BACKUP` | `ops/scripts/backup-production.sh` | Local validation or exceptional maintenance only | Defaults to `false`. Required before `REQUIRE_R2_BACKUP=false` is accepted outside production; production backups reject `REQUIRE_R2_BACKUP=false`. |
 | `ENFORCE_BACKUP_ENV_PERMISSIONS` | `ops/scripts/backup-production.sh` | Optional local permission check | Defaults to `false`. Production `/etc/munich-weekly/backup.env` is always checked for root ownership and no group/other permissions. |
+| `KEEP_BACKUP_STAGING` | `ops/scripts/backup-production.sh` | Local debugging only | Defaults to `false`. Production rejects `true`; plaintext backup staging data is removed after each run. |
 | `RETENTION_DAILY` | `ops/scripts/backup-production.sh` | Optional retention | Defaults to `14`. |
 | `RETENTION_WEEKLY` | `ops/scripts/backup-production.sh` | Optional retention | Defaults to `8`. |
 | `RETENTION_MONTHLY` | `ops/scripts/backup-production.sh` | Optional retention | Defaults to `12`. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ Document classes, ownership, and historical document policy are defined in
 | --- | --- | --- | --- |
 | [Deployment Guide](./deployment.md) | Operational guide | Backend/platform maintainer | Production ports, Nginx, PM2, Docker, profiles, or SSL flow changes. |
 | [Operations Quickstart](./operations/README.md) | Operational guide | Platform maintainer | Production workflow, deployment gates, alerting, or handoff state changes. |
+| [Deployment Readiness Plan](./operations/deployment-readiness-plan.md) | Implementation plan | Platform maintainer | Production script installation, backup readiness, smoke checks, or first one-command deployment status changes. |
 | [Production State](./operations/production-state.md) | Operational handoff | Platform maintainer | PRs are merged, production is deployed, timers are installed, secrets rotate, or Cloudflare settings change. |
 | [Operations Runbook](./operations/runbook.md) | Operational runbook | Platform maintainer | Daily checks, alerting, maintenance cadence, or production service operations change. |
 | [Dependency Maintenance](./operations/dependency-maintenance.md) | Operational runbook | Platform maintainer | Dependabot grouping, CI gates, package managers, or security policy changes. |

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -30,6 +30,7 @@ gh pr checks <pr-number>
 | --- | --- |
 | Normal production checks | [Operations Runbook](./runbook.md) |
 | Deploying | [Deployment Guide](../deployment.md) |
+| Current deployment readiness | [Deployment Readiness Plan](./deployment-readiness-plan.md) |
 | Backup or restore | [Backup and Restore](./backup-restore.md) |
 | Security incident or outage | [Incident Response](./incident-response.md) |
 | Dependabot emails or PRs | [Dependency Maintenance](./dependency-maintenance.md) |

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -40,10 +40,16 @@ sudo chmod 0600 /etc/munich-weekly/backup.env
 
 The file `/etc/munich-weekly/backup.env` must define `RESTIC_REPOSITORY`, `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `RCLONE_CONFIG`, `RCLONE_R2_SOURCE`, and `RCLONE_R2_BACKUP`.
 
+Both `/etc/munich-weekly/backup.env` and `/etc/munich-weekly/rclone.conf` must
+be owned by root and mode `0600`. The production backup and restore drill refuse
+to use files with broader permissions.
+
 Do not set `BACKUP_DRY_RUN=true`, `ALLOW_BACKUP_DRY_RUN=true`, or
 `REQUIRE_R2_BACKUP=false` in the production env file. The production script
 rejects dry-run mode and requires R2 object backups so a successful service run
 means both database data and upload objects were captured.
+Do not set `KEEP_BACKUP_STAGING=true` in production. The script rejects it for
+the production env path and removes plaintext staging files after each run.
 
 Install scripts and timers:
 
@@ -81,6 +87,9 @@ sudo journalctl -u munich-weekly-backup.service -n 120 --no-pager
 ```
 
 Expected result: restic prints the latest snapshots and the service exits successfully.
+The plaintext staging directory under `/var/backups/munich-weekly/<run-id>` is
+removed after the run; the retained backup is the encrypted restic snapshot plus
+the copied private R2 backup objects.
 
 If the service fails with `R2 backup manifest mismatch`, upload objects changed
 during the copy or the destination did not receive the same object set. Rerun

--- a/docs/operations/deployment-readiness-plan.md
+++ b/docs/operations/deployment-readiness-plan.md
@@ -1,0 +1,295 @@
+# Manual Production Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` or `superpowers:subagent-driven-development` to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Move Munich Weekly from manual server operation to a verified
+one-command production deployment without weakening backup, rollback, or smoke
+check guarantees.
+
+**Architecture:** Keep `origin/main` as the deployable artifact and install the
+versioned operations scripts from this repository onto the production server.
+The deploy command must run a verified backup first, then build/restart services
+and run local plus public smoke checks before the deployment is considered done.
+
+**Tech Stack:** GitHub Actions, GitHub PRs, SSH, systemd, restic, rclone,
+Docker Compose, PostgreSQL, PM2, Next.js, Spring Boot, Cloudflare.
+
+---
+
+## Current Verified State
+
+Verified on 2026-06-13 with read-only local and SSH checks.
+
+- GitHub `main`: `57ecc3783dfbb34b442995bcf4b9660c75b0c749`.
+- Production checkout: `/home/deploy/munich-weekly` at `bb05283`, branch
+  `main`, clean worktree.
+- Running services: `mw-backend` and `mw-postgres` are up; PM2 process
+  `munich-frontend` is online.
+- Local production probes from the server: frontend `200`, backend health
+  `200`.
+- Public Cloudflare probes from the server: `/` returns `403` challenge,
+  `/api/layout/health` returns `403` challenge, `/favicon.ico` returns `200`.
+- `restic`, `rclone`, patched operations scripts, backup/status systemd units,
+  root-only `backup.env`, root-only `rclone.conf`, and narrow deploy sudoers
+  were installed on 2026-06-13.
+- R2 backup bucket `munichweekly-ops-backups` was created on 2026-06-13.
+- First successful backup snapshot: `89759db3` on 2026-06-13.
+- Restore drill succeeded from snapshot `89759db3` on 2026-06-13.
+- `munich-weekly-backup.timer` is enabled. `munich-weekly-status.timer` is not
+  enabled yet because the public Cloudflare smoke check still returns `403`.
+
+## Hard Stops
+
+- Do not deploy until a production backup service exists and one backup run has
+  succeeded.
+- Do not print, commit, or paste production secrets. Use `sudoedit` or the
+  password manager for `/etc/munich-weekly/*.env` and `rclone.conf`.
+- Do not run the deploy script while the public smoke URL is blocked by the
+  Cloudflare challenge. The reviewed smoke URL must exercise the public app or
+  public backend through Cloudflare and return `200`.
+- Do not include open dependency PRs in this deployment. PR #37 is a green
+  frontend security PR that should be handled promptly after current `main` is
+  deployed; PR #13 and PR #31 are major upgrades and need separate validation;
+  PR #36, #29, #21, #16, and #14 are failing, draft, or blocked.
+- Any command that installs packages, writes `/etc`, starts a backup, deploys,
+  restarts services, reloads Nginx, or changes Cloudflare needs explicit user
+  approval.
+- Do not enable `munich-weekly-backup.timer` until the installed backup script
+  deletes plaintext staging data after each run and the restore drill has passed.
+
+## Phase 1: Install Deployment Prerequisites
+
+- [x] **Confirm maintenance window**
+
+  Record a quiet 30-minute deployment window and confirm the user approves
+  production changes for this window.
+
+- [x] **Install required server packages**
+
+  On the server:
+
+  ```bash
+  sudo apt-get update
+  sudo apt-get install -y restic rclone
+  ```
+
+  Expected: `command -v restic` and `command -v rclone` both return paths.
+
+- [x] **Verify backup script safety patch**
+
+  Before installing scripts on production, verify the local script version
+  enforces root-only permissions for `backup.env` and `rclone.conf`, rejects
+  `KEEP_BACKUP_STAGING=true` in production, and removes the plaintext
+  `RUN_DIR` staging directory on exit.
+
+- [x] **Install versioned scripts and systemd units**
+
+  Source files must come from reviewed `origin/main`, not from hot-edited server
+  files. If the server checkout has not been deployed yet, fetch `main` and use
+  `git show origin/main:<path>` to install the files without changing the
+  running app revision.
+
+  Install:
+
+  ```text
+  ops/scripts/backup-production.sh -> /usr/local/sbin/munich-weekly-backup.sh
+  ops/scripts/deploy-production.sh -> /usr/local/sbin/munich-weekly-deploy.sh
+  ops/scripts/production-status.sh -> /usr/local/sbin/munich-weekly-status.sh
+  ops/scripts/restore-backup-drill.sh -> /usr/local/sbin/munich-weekly-restore-drill.sh
+  ops/scripts/notify-ops.sh -> /usr/local/sbin/munich-weekly-notify-ops.sh
+  ops/systemd/munich-weekly-backup.service -> /etc/systemd/system/munich-weekly-backup.service
+  ops/systemd/munich-weekly-backup.timer -> /etc/systemd/system/munich-weekly-backup.timer
+  ops/systemd/munich-weekly-status.service -> /etc/systemd/system/munich-weekly-status.service
+  ops/systemd/munich-weekly-status.timer -> /etc/systemd/system/munich-weekly-status.timer
+  ops/systemd/munich-weekly-alert@.service -> /etc/systemd/system/munich-weekly-alert@.service
+  ```
+
+  Then run:
+
+  ```bash
+  sudo systemctl daemon-reload
+  ```
+
+  Before adding sudoers, verify ownership and permissions:
+
+  ```bash
+  sudo stat -c '%U %G %a %n' /usr/local/sbin/munich-weekly-backup.sh /etc/systemd/system/munich-weekly-backup.service
+  ```
+
+  Expected: both files are owned by `root root` and are not writable by group or
+  others.
+
+- [x] **Create backup configuration**
+
+  Create root-only files:
+
+  ```bash
+  sudo install -d -m 0700 /etc/munich-weekly
+  sudoedit /etc/munich-weekly/backup.env
+  sudoedit /etc/munich-weekly/rclone.conf
+  sudo chown root:root /etc/munich-weekly/backup.env /etc/munich-weekly/rclone.conf
+  sudo chmod 0600 /etc/munich-weekly/backup.env /etc/munich-weekly/rclone.conf
+  ```
+
+  `/etc/munich-weekly/backup.env` must define the variables documented in
+  [Backup and Restore Runbook](./backup-restore.md): `RESTIC_REPOSITORY`,
+  `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+  `RCLONE_CONFIG`, `RCLONE_R2_SOURCE`, and `RCLONE_R2_BACKUP`.
+
+- [x] **Add narrow sudo rule for the deploy user**
+
+  Verify the systemctl path:
+
+  ```bash
+  command -v systemctl
+  ```
+
+  Then add a narrow sudoers entry with `visudo`:
+
+  ```text
+  deploy ALL=(root) NOPASSWD: /usr/bin/systemctl start munich-weekly-backup.service
+  ```
+
+  If `command -v systemctl` is not `/usr/bin/systemctl`, use the verified path.
+  Do not grant broad passwordless sudo.
+
+## Phase 2: Prove Backup And Restore
+
+- [x] **Initialize the restic repository**
+
+  ```bash
+  sudo bash -lc 'set -a; . /etc/munich-weekly/backup.env; set +a; restic snapshots >/dev/null 2>&1 || restic init'
+  ```
+
+- [x] **Run the first production backup**
+
+  ```bash
+  sudo systemctl start munich-weekly-backup.service
+  sudo journalctl -u munich-weekly-backup.service -n 160 --no-pager
+  ```
+
+  Result: the service exited successfully and created snapshot `89759db3`.
+
+- [x] **Run a restore drill before the first automated deploy**
+
+  ```bash
+  sudo /usr/local/sbin/munich-weekly-restore-drill.sh
+  ```
+
+  Result: `Restore drill succeeded from snapshot 89759db3`.
+
+- [x] **Enable backup timer**
+
+  ```bash
+  sudo systemctl enable --now munich-weekly-backup.timer
+  sudo systemctl list-timers munich-weekly-backup.timer --no-pager
+  ```
+
+  Result: backup timer enabled for daily 02:30 UTC runs.
+
+- [ ] **Enable status timer after public smoke is fixed**
+
+  Do not enable `munich-weekly-status.timer` while `/` and
+  `/api/layout/health` return Cloudflare `403`, because the status check will
+  correctly fail and create alert noise.
+
+## Phase 3: Fix The Public Smoke Check
+
+- [ ] **Choose the public smoke URL**
+
+  Preferred: configure Cloudflare so `https://munichweekly.art/api/layout/health`
+  returns `200` from the production server and remains uncached. This verifies
+  the public edge can reach the backend without requiring a browser challenge.
+
+  Do not use static assets such as `/favicon.ico` as the deployment smoke URL.
+  A static asset can return `200` while the public frontend or backend is still
+  blocked by Cloudflare.
+
+  Current blocker: the Cloudflare connector can manage R2 but is unauthorized
+  for zone/ruleset changes. Use the Cloudflare dashboard or re-authorize the
+  connector with zone/ruleset permissions. The required rule should only affect
+  `http.host == "munichweekly.art"` and
+  `http.request.uri.path == "/api/layout/health"`, should not cache the
+  response, and should skip the rule or setting that currently challenges this
+  health path.
+
+- [ ] **Verify the selected URL before deployment**
+
+  ```bash
+  curl -fsSI --connect-timeout 10 --max-time 20 https://munichweekly.art/api/layout/health
+  ```
+
+  Expected for the preferred path: HTTP `200` and no `X-Powered-By` header.
+
+## Phase 4: Deploy `origin/main`
+
+- [ ] **Re-check deploy target**
+
+  ```bash
+  git ls-remote origin refs/heads/main
+  ssh munichweekly 'git -C /home/deploy/munich-weekly rev-parse HEAD'
+  ssh munichweekly 'git -C /home/deploy/munich-weekly status --short'
+  ```
+
+  Expected: local `origin/main` is the intended deployment target and the
+  production worktree is clean.
+
+- [ ] **Run pre-deploy status**
+
+  ```bash
+  ssh munichweekly 'sudo /usr/local/sbin/munich-weekly-status.sh'
+  ```
+
+  Expected: Docker, backend health, frontend local headers, git status, and
+  backup timer checks pass. If public root still returns a Cloudflare challenge,
+  confirm this is the expected WAF behavior before continuing.
+
+- [ ] **Run the one-command deploy**
+
+  Preferred command after Phase 3 is fixed:
+
+  ```bash
+  ssh munichweekly '/usr/local/sbin/munich-weekly-deploy.sh'
+  ```
+
+  Expected: deployment succeeds from `bb05283` to the current `origin/main` SHA.
+
+- [ ] **Run post-deploy checks**
+
+  ```bash
+  ssh munichweekly 'git -C /home/deploy/munich-weekly rev-parse --short HEAD'
+  ssh munichweekly 'docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"'
+  ssh munichweekly 'pm2 status --no-color'
+  ssh munichweekly 'curl -fsS http://127.0.0.1:8080/api/layout/health'
+  ssh munichweekly 'curl -fsSI http://127.0.0.1:3000/ | sed -n "1,20p"'
+  ```
+
+  Also verify the public site in a browser through Cloudflare.
+
+- [ ] **Update the deployment record**
+
+  Fill in the deployment record in [Production State](./production-state.md)
+  with the previous SHA, deployed SHA, backup result, deploy command, smoke
+  checks, timer state, and rollback status.
+
+## Rollback Plan
+
+The deploy script attempts code rollback automatically after post-checkout
+failures. This rollback does not restore PostgreSQL, R2 objects, or local
+uploads. If the deployed change can alter schema or data, decide whether a
+database/object restore is required before declaring rollback complete.
+
+If manual code rollback is still needed, use the previous SHA recorded before
+deployment:
+
+```bash
+ssh munichweekly 'git -C /home/deploy/munich-weekly checkout --detach <previous-sha>'
+ssh munichweekly 'cd /home/deploy/munich-weekly/backend && docker compose up -d --build backend'
+ssh munichweekly 'cd /home/deploy/munich-weekly/frontend && npm ci && npm run build && pm2 startOrReload ecosystem.config.cjs --only munich-frontend && pm2 save'
+```
+
+After rollback, run the post-deploy checks and record the rollback in
+[Production State](./production-state.md).

--- a/docs/operations/production-state.md
+++ b/docs/operations/production-state.md
@@ -9,17 +9,19 @@ before relying on it.
 
 ## Current Handoff
 
-Last updated: 2026-06-11.
+Last updated: 2026-06-13.
 
 | Area | State | Next action |
 | --- | --- | --- |
-| Ops hardening PR | PR #3 is ready for review, CI green, not merged. | Review and merge when approved. |
-| Production deploy | Not performed for PR #3. | Schedule maintenance window before deploying. |
-| Backup timer | Scripts and units exist in repo; server installation not confirmed here. | Verify after merge on production. |
-| Restore drill | Script exists in repo; latest successful drill not recorded here. | Run after backup setup is confirmed. |
-| Status timer and alerts | Scripts and units exist in repo; server installation not confirmed here. | Install or verify on production. |
+| Ops hardening PR | PR #3 merged on 2026-06-10. | Deploy merged operations code after readiness gates pass. |
+| Production deploy | Not performed for current `main`. Production is still at `bb05283`; GitHub `main` is `57ecc37`. | Blocked on Cloudflare public smoke check; follow [Deployment Readiness Plan](./deployment-readiness-plan.md). |
+| Backup timer | `restic`, `rclone`, patched scripts, systemd units, root-only `backup.env`, root-only `rclone.conf`, and narrow deploy sudoers are installed. Backup timer is enabled. First successful snapshot: `89759db3` on 2026-06-13. | Monitor next scheduled backup on 2026-06-14 and keep restic password available from local `.env.local`. |
+| Restore drill | Restore drill succeeded from snapshot `89759db3` on 2026-06-13. | Run monthly and after backup script changes. |
+| Status timer and alerts | Scripts and units are installed, but status timer is not enabled because public Cloudflare smoke currently returns `403`. | Enable after the public health URL returns `200`. |
 | Cloudflare origin protection | Repo contains Nginx snippets and allowlist automation; production state not confirmed here. | Verify carefully before Nginx reload. |
-| Dependabot PRs | Several were opened from old `main`; PR #3 updates/removes many affected manifests. | Merge PR #3 first, then close or rebase stale Dependabot PRs. |
+| Public smoke check | Server-side `curl` to `/` and `/api/layout/health` receives Cloudflare `403` challenge even with a browser User-Agent; `/favicon.ico` returns `200` but is not an acceptable deploy smoke URL. Current Cloudflare connector can manage R2 but is unauthorized for zone/ruleset changes. | Add a Cloudflare rule so `/api/layout/health` returns `200` uncached, or re-authorize the connector with zone/ruleset permissions. |
+| R2 backup bucket | `munichweekly-ops-backups` was created on 2026-06-13 in R2 location `WEUR`. | Use only for encrypted restic data and copied object backups. |
+| Dependabot PRs | Open dependency PRs are not part of the deployment target. #37 is a green frontend security PR; #13 and #31 are major upgrades; #36, #29, #21, #16, and #14 are failing, draft, or blocked. | Deploy current stable `main` first, then triage #37 promptly through the dependency maintenance runbook. |
 
 ## Required Deployment Record
 

--- a/ops/scripts/backup-production.sh
+++ b/ops/scripts/backup-production.sh
@@ -25,19 +25,22 @@ require_cmd() {
 }
 
 stat_owner_mode() {
-  if stat -c '%U %a' "$BACKUP_ENV" 2>/dev/null; then
+  local file_path="$1"
+  if stat -c '%U %a' "$file_path" 2>/dev/null; then
     return 0
   fi
-  stat -f '%Su %Lp' "$BACKUP_ENV" 2>/dev/null
+  stat -f '%Su %Lp' "$file_path" 2>/dev/null
 }
 
-require_backup_env_permissions() {
+require_root_only_file_permissions() {
+  local file_path="$1"
+  local label="$2"
   require_cmd stat
   local owner mode owner_perms group_perms other_perms
-  read -r owner mode < <(stat_owner_mode) || die "Could not stat backup env file: $BACKUP_ENV"
+  read -r owner mode < <(stat_owner_mode "$file_path") || die "Could not stat $label: $file_path"
 
   if [ "$owner" != "root" ]; then
-    die "Backup env file must be owned by root: $BACKUP_ENV"
+    die "$label must be owned by root: $file_path"
   fi
 
   mode=$((10#$mode))
@@ -46,12 +49,27 @@ require_backup_env_permissions() {
   other_perms=$((mode % 10))
 
   if [ $((owner_perms & 4)) -eq 0 ] || [ "$group_perms" -ne 0 ] || [ "$other_perms" -ne 0 ]; then
-    die "Backup env file must be readable only by root: $BACKUP_ENV"
+    die "$label must be readable only by root: $file_path"
   fi
+}
+
+require_backup_env_permissions() {
+  require_root_only_file_permissions "$BACKUP_ENV" "Backup env file"
 }
 
 write_sha256sums() {
   "${SHA256_CMD[@]}" "$RUN_DIR/postgres.dump" "$RUN_DIR/uploads.tar.gz" > "$RUN_DIR/SHA256SUMS"
+}
+
+cleanup_staging() {
+  if [ "${KEEP_BACKUP_STAGING:-false}" = "true" ]; then
+    return
+  fi
+  if [ -n "${RUN_DIR:-}" ] && [ -d "$RUN_DIR" ] && [ "$RUN_DIR" != "/" ]; then
+    case "$RUN_DIR" in
+      "$BACKUP_WORK_DIR"/*) rm -rf "$RUN_DIR" ;;
+    esac
+  fi
 }
 
 require_bool ENFORCE_BACKUP_ENV_PERMISSIONS "$ENFORCE_BACKUP_ENV_PERMISSIONS"
@@ -79,14 +97,19 @@ REQUIRE_R2_BACKUP="${REQUIRE_R2_BACKUP:-true}"
 BACKUP_DRY_RUN="${BACKUP_DRY_RUN:-false}"
 ALLOW_BACKUP_DRY_RUN="${ALLOW_BACKUP_DRY_RUN:-false}"
 ALLOW_INCOMPLETE_R2_BACKUP="${ALLOW_INCOMPLETE_R2_BACKUP:-false}"
+KEEP_BACKUP_STAGING="${KEEP_BACKUP_STAGING:-false}"
 
 require_bool REQUIRE_R2_BACKUP "$REQUIRE_R2_BACKUP"
 require_bool BACKUP_DRY_RUN "$BACKUP_DRY_RUN"
 require_bool ALLOW_BACKUP_DRY_RUN "$ALLOW_BACKUP_DRY_RUN"
 require_bool ALLOW_INCOMPLETE_R2_BACKUP "$ALLOW_INCOMPLETE_R2_BACKUP"
+require_bool KEEP_BACKUP_STAGING "$KEEP_BACKUP_STAGING"
 
 if [ "$BACKUP_ENV" = "$PRODUCTION_BACKUP_ENV" ] && [ "$BACKUP_DRY_RUN" = "true" ]; then
   die "BACKUP_DRY_RUN cannot be true when BACKUP_ENV=$PRODUCTION_BACKUP_ENV"
+fi
+if [ "$BACKUP_ENV" = "$PRODUCTION_BACKUP_ENV" ] && [ "$KEEP_BACKUP_STAGING" = "true" ]; then
+  die "KEEP_BACKUP_STAGING cannot be true when BACKUP_ENV=$PRODUCTION_BACKUP_ENV"
 fi
 if [ "$BACKUP_DRY_RUN" = "true" ] && [ "$ALLOW_BACKUP_DRY_RUN" != "true" ]; then
   die "BACKUP_DRY_RUN=true requires ALLOW_BACKUP_DRY_RUN=true"
@@ -117,6 +140,9 @@ if [ "$REQUIRE_R2_BACKUP" = "true" ]; then
   : "${RCLONE_R2_SOURCE:?RCLONE_R2_SOURCE is required when REQUIRE_R2_BACKUP=true}"
   : "${RCLONE_R2_BACKUP:?RCLONE_R2_BACKUP is required when REQUIRE_R2_BACKUP=true}"
   export RCLONE_CONFIG="${RCLONE_CONFIG:-/etc/munich-weekly/rclone.conf}"
+  if [ "$BACKUP_ENV" = "$PRODUCTION_BACKUP_ENV" ] || [ "$ENFORCE_BACKUP_ENV_PERMISSIONS" = "true" ]; then
+    require_root_only_file_permissions "$RCLONE_CONFIG" "Rclone config file"
+  fi
   R2_BACKUP_PATH="${RCLONE_R2_BACKUP}/snapshots/${DATE_UTC}"
   if [ "$BACKUP_DRY_RUN" != "true" ]; then
     require_cmd rclone
@@ -125,6 +151,7 @@ fi
 
 mkdir -p "$BACKUP_WORK_DIR" "$RUN_DIR"
 chmod 0700 "$BACKUP_WORK_DIR" "$RUN_DIR"
+trap cleanup_staging EXIT
 
 if [ "$REQUIRE_R2_BACKUP" != "true" ]; then
   printf '%s\n' \

--- a/ops/scripts/restore-backup-drill.sh
+++ b/ops/scripts/restore-backup-drill.sh
@@ -34,6 +34,35 @@ require_bool() {
   esac
 }
 
+stat_owner_mode() {
+  local file_path="$1"
+  if stat -c '%U %a' "$file_path" 2>/dev/null; then
+    return 0
+  fi
+  stat -f '%Su %Lp' "$file_path" 2>/dev/null
+}
+
+require_root_only_file_permissions() {
+  local file_path="$1"
+  local label="$2"
+  require_cmd stat
+  local owner mode owner_perms group_perms other_perms
+  read -r owner mode < <(stat_owner_mode "$file_path") || die "Could not stat $label: $file_path"
+
+  if [ "$owner" != "root" ]; then
+    die "$label must be owned by root: $file_path"
+  fi
+
+  mode=$((10#$mode))
+  owner_perms=$((mode / 100 % 10))
+  group_perms=$((mode / 10 % 10))
+  other_perms=$((mode % 10))
+
+  if [ $((owner_perms & 4)) -eq 0 ] || [ "$group_perms" -ne 0 ] || [ "$other_perms" -ne 0 ]; then
+    die "$label must be readable only by root: $file_path"
+  fi
+}
+
 cleanup() {
   if command -v docker >/dev/null 2>&1 && [ -n "${DRILL_CONTAINER_NAME:-}" ]; then
     local container_id
@@ -296,10 +325,13 @@ main() {
   require_bool ALLOW_EMPTY_R2_RESTORE "$ALLOW_EMPTY_R2_RESTORE"
 
   [ -r "$BACKUP_ENV" ] || die "Backup env file is missing or unreadable: $BACKUP_ENV"
+  require_root_only_file_permissions "$BACKUP_ENV" "Backup env file"
 
   set -a
   . "$BACKUP_ENV"
   set +a
+  export RCLONE_CONFIG="${RCLONE_CONFIG:-/etc/munich-weekly/rclone.conf}"
+  require_root_only_file_permissions "$RCLONE_CONFIG" "Rclone config file"
 
   mkdir -p "$RESTORE_PARENT_DIR"
   RESTORE_WORK_DIR="$(mktemp -d "$RESTORE_PARENT_DIR/mw-restore-drill.XXXXXXXX")"


### PR DESCRIPTION
## Summary
- harden production backup and restore scripts by enforcing root-only secret config permissions
- remove plaintext backup staging after each run and document code-only rollback limits
- add a current deployment readiness handoff, including the completed backup setup and remaining Cloudflare smoke-check blocker

## Verification
- bash -n ops/scripts/backup-production.sh
- bash -n ops/scripts/restore-backup-drill.sh
- ./scripts/check-docs.sh
- git diff --check
- production: restic/rclone installed, first backup snapshot 89759db3 created, restore drill succeeded from snapshot 89759db3, backup timer enabled

## Notes
- Production deploy has not been run. It remains blocked until Cloudflare allows a real public health URL such as /api/layout/health to return 200 through the edge.