### PR TITLE
docs: record production deployment

### DIFF
--- a/docs/operations/production-state.md
+++ b/docs/operations/production-state.md
@@ -13,17 +13,38 @@ Last updated: 2026-06-13.
 
 | Area | State | Next action |
 | --- | --- | --- |
-| Ops hardening PR | PR #3 merged on 2026-06-10. | Deploy merged operations code after readiness gates pass. |
-| Production deploy | Not performed for current `main`. Production is still at `bb05283`; GitHub `main` is `57ecc37`. | Blocked on Cloudflare public smoke check; follow [Deployment Readiness Plan](./deployment-readiness-plan.md). |
-| Backup timer | `restic`, `rclone`, patched scripts, systemd units, root-only `backup.env`, root-only `rclone.conf`, and narrow deploy sudoers are installed. Backup timer is enabled. First successful snapshot: `89759db3` on 2026-06-13. | Monitor next scheduled backup on 2026-06-14 and keep restic password available from local `.env.local`. |
+| Ops hardening PR | PR #38 merged and deployed on 2026-06-13. | Keep using PR + CI + deploy workflow for future operations changes. |
+| Production deploy | Production is deployed at `449a6f0`; previous production SHA was `bb05283`. | Triage remaining Dependabot/security PRs after this stable deploy. |
+| Backup timer | `restic`, `rclone`, patched scripts, systemd units, root-only `backup.env`, root-only `rclone.conf`, and narrow deploy sudoers are installed. Backup timer is enabled. First successful snapshot: `89759db3`; latest deploy snapshot: `53833799`. | Monitor next scheduled backup on 2026-06-14 and keep restic password available from local `.env.local`. |
 | Restore drill | Restore drill succeeded from snapshot `89759db3` on 2026-06-13. | Run monthly and after backup script changes. |
-| Status timer and alerts | Scripts and units are installed, but status timer is not enabled because public Cloudflare smoke currently returns `403`. | Enable after the public health URL returns `200`. |
+| Status timer and alerts | Status script passes and `munich-weekly-status.timer` is enabled. Next run: 2026-06-14 08:01:48 UTC. | Review status timer output after first scheduled run. |
 | Cloudflare origin protection | Repo contains Nginx snippets and allowlist automation; production state not confirmed here. | Verify carefully before Nginx reload. |
-| Public smoke check | Server-side `curl` to `/` and `/api/layout/health` receives Cloudflare `403` challenge even with a browser User-Agent; `/favicon.ico` returns `200` but is not an acceptable deploy smoke URL. Current Cloudflare connector can manage R2 but is unauthorized for zone/ruleset changes. | Add a Cloudflare rule so `/api/layout/health` returns `200` uncached, or re-authorize the connector with zone/ruleset permissions. |
+| Public smoke check | Server-side `curl` to `/` and `/api/layout/health` returns `200`. Cloudflare Bot Fight Mode was disabled because it challenged production health checks. | Keep Bot Fight Mode off unless a replacement health-check allowlist is proven first. |
 | R2 backup bucket | `munichweekly-ops-backups` was created on 2026-06-13 in R2 location `WEUR`. | Use only for encrypted restic data and copied object backups. |
 | Dependabot PRs | Open dependency PRs are not part of the deployment target. #37 is a green frontend security PR; #13 and #31 are major upgrades; #36, #29, #21, #16, and #14 are failing, draft, or blocked. | Deploy current stable `main` first, then triage #37 promptly through the dependency maintenance runbook. |
+| Host package maintenance | Status script reported reboot required and 49 apt-upgradable packages on 2026-06-13. | Schedule a maintenance window for OS updates and reboot after confirming backup health. |
 
-## Required Deployment Record
+## Latest Deployment Record
+
+```text
+Deployment date: 2026-06-13
+Operator: Codex with user approval
+Deployed git SHA: 449a6f0
+Previous git SHA: bb05283
+Backup before deploy: pass, snapshot id 53833799
+Deploy command: PUBLIC_URL=https://munichweekly.art/api/layout/health /usr/local/sbin/munich-weekly-deploy.sh
+Backend health: pass, local /api/layout/health returned 200
+Frontend local check: pass, local root returned 200
+Public HTTPS check: pass, / and /api/layout/health returned 200
+PM2 status: munich-frontend online
+Docker status: mw-backend up, mw-postgres up and healthy
+Backup timer status: enabled, next run 2026-06-14 02:34:01 UTC
+Status timer status: enabled, next run 2026-06-14 08:01:48 UTC
+Rollback needed: no
+Notes: Cloudflare Bot Fight Mode was disabled because it challenged curl-based health checks.
+```
+
+## Deployment Record Template
 
 After each production deployment, update this section:
 


### PR DESCRIPTION
## Summary
- record the 2026-06-13 production deployment from bb05283 to 449a6f0
- note backup snapshot 53833799, enabled status timer, and Cloudflare Bot Fight Mode change
- record host maintenance follow-up for OS updates and reboot

## Verification
- ./scripts/check-docs.sh
- git diff --check