### PR TITLE
[codex] Harden admin frontend API auth and hero sync

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -129,7 +129,7 @@ identity.
 | `NEXT_PUBLIC_API_URL` | `frontend/next.config.js`, frontend API routes | Optional | Defaults to `http://localhost:8080/api` for rewrites. `sync-hero` normalizes a trailing `/api` before appending `/api/users/me`; check each frontend API route before changing this value globally. |
 | `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | `src/app/submit/page.tsx` | Anonymous submission CAPTCHA | Public site key for the Turnstile widget. |
 | `DEBUG_CONFIG_API` | `src/app/frontend-api/config/route.ts` | Optional debugging | Set to `1` for config API debug logging. |
-| `HERO_IMAGE_ALLOWED_ORIGINS` | `src/app/frontend-api/admin/sync-hero/route.ts` | Optional remote homepage hero sync origins | Comma-separated exact HTTPS origins allowed for admin hero image sync, in addition to the current built-in image CDN origins. Do not include path segments, credentials, or wildcards. |
+| `HERO_IMAGE_ALLOWED_ORIGINS` | `src/app/frontend-api/admin/sync-hero/route.ts` | Optional remote homepage hero sync origins | Comma-separated exact HTTPS origins allowed for admin hero image sync, in addition to the current built-in image CDN origins. Do not include path segments, credentials, or wildcards. The route compares the parsed URL origin exactly, rejects private/local hosts, and rebuilds remote downloads from the allowlisted origin plus the submitted path and query string. |
 | `NODE_ENV` | Next.js and image utilities | Managed by Next.js | `development` changes image optimization and upload rewrite behavior. |
 
 ## Image Worker

--- a/docs/frontend-api.md
+++ b/docs/frontend-api.md
@@ -39,9 +39,9 @@ frontend process.
 | --- | --- | --- | --- | --- |
 | `GET` | `/frontend-api/config` | `frontend/src/app/frontend-api/config/route.ts` | Public | Reads homepage configuration from `frontend/public/config/homepage.json`, falling back to `frontend/src/lib/config.ts`. Supports ETag caching and `_force=1`. |
 | `POST` | `/frontend-api/csp-report` | `frontend/src/app/frontend-api/csp-report/route.ts` | Public | Accepts browser CSP violation reports from the Nginx report-only policy and returns `204 No Content`. |
-| `GET` | `/frontend-api/admin/config` | `frontend/src/app/frontend-api/admin/config/route.ts` | JWT plus backend admin check | Reads homepage configuration for the admin UI. Token is accepted from the `jwt` cookie or `Authorization: Bearer` header, then verified through backend `/api/users/me`. |
-| `POST` | `/frontend-api/admin/config` | `frontend/src/app/frontend-api/admin/config/route.ts` | JWT plus backend admin check | Merges posted homepage configuration into `frontend/public/config/homepage.json` and sets `lastUpdated`. |
-| `POST` | `/frontend-api/admin/sync-hero` | `frontend/src/app/frontend-api/admin/sync-hero/route.ts` | JWT plus backend admin check | Copies a hero image from an allowlisted remote HTTPS JPEG/PNG origin or from `backend/uploads/hero.jpg` into `frontend/public/images/home/hero.jpg`. |
+| `GET` | `/frontend-api/admin/config` | `frontend/src/app/frontend-api/admin/config/route.ts` | `Authorization: Bearer` JWT plus backend admin check | Reads homepage configuration for the admin UI. Token is accepted only from the `Authorization: Bearer` header, then verified through backend `/api/users/me`. |
+| `POST` | `/frontend-api/admin/config` | `frontend/src/app/frontend-api/admin/config/route.ts` | `Authorization: Bearer` JWT plus backend admin check | Merges posted homepage configuration into `frontend/public/config/homepage.json` and sets `lastUpdated`. |
+| `POST` | `/frontend-api/admin/sync-hero` | `frontend/src/app/frontend-api/admin/sync-hero/route.ts` | `Authorization: Bearer` JWT plus backend admin check | Copies a hero image from an allowlisted remote HTTPS JPEG/PNG origin or from `backend/uploads/hero.jpg` into `frontend/public/images/home/hero.jpg`. |
 | `POST` | `/frontend-api/admin/upload` | `frontend/src/app/frontend-api/admin/upload/route.ts` | Not applicable | Disabled legacy upload endpoint. Always returns `410 Gone` with backend upload alternatives. |
 
 ## Operational Notes
@@ -57,14 +57,20 @@ frontend process.
 - Admin config routes that call the backend use `NEXT_PUBLIC_API_URL` as their
   backend base. For those server-side route handlers, use the backend origin
   expected by the code, not a frontend path.
+- Admin frontend API routes require an explicit `Authorization: Bearer` JWT.
+  They do not accept the `jwt` cookie, so browser ambient credentials are not a
+  valid authentication path for admin config or hero sync operations.
 - `POST /frontend-api/admin/sync-hero` verifies the token through backend
   `/api/users/me` before parsing the request body, reading local files, fetching
   remote images, or writing the frontend hero image. Remote sync only accepts
   JPEG/PNG responses from exact HTTPS origins in the built-in image CDN allowlist
-  or `HERO_IMAGE_ALLOWED_ORIGINS`, and rejects redirects and images over 30 MB.
-  Missing `imageUrl` falls back to `backend/uploads/hero.jpg`; upload results
-  `/uploads/hero.jpg`, `/uploads/hero.jpeg`, and `/uploads/hero.png` are treated
-  as local backend files instead of remote fetch targets.
+  or `HERO_IMAGE_ALLOWED_ORIGINS`, rejects credentials, private/local hostnames,
+  redirects, and images over 30 MB, then downloads a canonical URL rebuilt from
+  the allowlisted origin plus the submitted path and query string. URL fragments
+  are discarded. Missing `imageUrl` falls back to `backend/uploads/hero.jpg`;
+  upload results `/uploads/hero.jpg`, `/uploads/hero.jpeg`, and
+  `/uploads/hero.png` are treated as local backend files instead of remote fetch
+  targets.
 - Homepage image upload itself uses backend endpoints such as
   `/api/submissions/admin/upload-hero`; the frontend sync route only copies the
   resulting image into the frontend public asset location.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test:routes": "tsx test/sync-hero-route.test.ts && tsx test/csp-report-route.test.ts",
+    "test:routes": "tsx test/sync-hero-route.test.ts && tsx test/admin-config-route.test.ts && tsx test/csp-report-route.test.ts",
     "lint": "eslint src"
   },
   "dependencies": {

--- a/frontend/src/app/frontend-api/admin/config/route.ts
+++ b/frontend/src/app/frontend-api/admin/config/route.ts
@@ -4,13 +4,9 @@ import path from 'path';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
-// Get JWT token from request
+// Get JWT token from the Authorization header. Admin frontend APIs do not accept
+// JWT cookies so browsers cannot trigger them with ambient credentials.
 function getAuthToken(request: NextRequest): string | null {
-  const authCookie = request.cookies.get('jwt')?.value;
-  if (authCookie) {
-    return authCookie;
-  }
-
   const authHeader = request.headers.get('Authorization');
   if (authHeader && authHeader.startsWith('Bearer ')) {
     return authHeader.substring(7);
@@ -68,7 +64,7 @@ export async function GET(request: NextRequest) {
       success: true,
       config
     });
-    
+
   } catch (error) {
     return NextResponse.json(
       { error: `Failed to retrieve configuration: ${error instanceof Error ? error.message : 'Unknown error'}` },
@@ -140,4 +136,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-} 
+}

--- a/frontend/src/app/frontend-api/admin/sync-hero/route.ts
+++ b/frontend/src/app/frontend-api/admin/sync-hero/route.ts
@@ -34,11 +34,6 @@ function getApiBaseUrl(): string {
 }
 
 function getAuthToken(request: NextRequest): string | null {
-  const authCookie = request.cookies.get('jwt')?.value;
-  if (authCookie) {
-    return authCookie;
-  }
-
   const authHeader = request.headers.get('Authorization');
   if (authHeader && authHeader.startsWith('Bearer ')) {
     return authHeader.substring(7);
@@ -120,11 +115,28 @@ function resolveHeroSource(imageUrl: unknown): HeroSource {
     throw new HeroSyncError('Remote hero image URL points to a private or local host', 400);
   }
 
-  if (!getAllowedRemoteOrigins().has(parsedUrl.origin)) {
+  const allowedOrigin = findAllowedRemoteOrigin(parsedUrl.origin);
+  if (!allowedOrigin) {
     throw new HeroSyncError('Remote hero image origin is not allowed', 400);
   }
 
-  return { type: 'remote', url: parsedUrl };
+  return { type: 'remote', url: canonicalizeRemoteHeroUrl(parsedUrl, allowedOrigin) };
+}
+
+function findAllowedRemoteOrigin(candidateOrigin: string): string | null {
+  for (const allowedOrigin of getAllowedRemoteOrigins()) {
+    if (candidateOrigin === allowedOrigin) {
+      return allowedOrigin;
+    }
+  }
+  return null;
+}
+
+function canonicalizeRemoteHeroUrl(parsedUrl: URL, allowedOrigin: string): URL {
+  const canonicalUrl = new URL(allowedOrigin);
+  canonicalUrl.pathname = parsedUrl.pathname;
+  canonicalUrl.search = parsedUrl.search;
+  return canonicalUrl;
 }
 
 function isPrivateOrLocalHostname(hostname: string): boolean {

--- a/frontend/src/hooks/useConfigAdmin.ts
+++ b/frontend/src/hooks/useConfigAdmin.ts
@@ -41,18 +41,13 @@ export function useConfigAdmin() {
     setError(null);
 
     try {
-      // Add additional verification measures - explicitly send token as cookie
-      const token = localStorage.getItem('jwt');
-      // Ensure cookie can be accessed on both client and server side, preventing security restrictions
-      document.cookie = `jwt=${token || ''}; path=/; max-age=3600; SameSite=None; Secure=false`;
-
       const response = await fetch('/frontend-api/admin/config', {
         method: 'GET',
+        credentials: 'omit',
         headers: {
           'Content-Type': 'application/json',
           ...getAuthHeader()
-        },
-        credentials: 'include'
+        }
       });
 
       if (!response.ok) {
@@ -108,11 +103,6 @@ export function useConfigAdmin() {
       const formData = new FormData();
       formData.append('file', file);
 
-      // Add additional verification measures - ensure token is also in cookie
-      const token = localStorage.getItem('jwt');
-      // Ensure cookie can be accessed on both client and server side, preventing security restrictions
-      document.cookie = `jwt=${token || ''}; path=/; max-age=3600; SameSite=None; Secure=false`;
-
       // Use new dedicated hero image upload endpoint
       const response = await fetch('/api/submissions/admin/upload-hero', {
         method: 'POST',
@@ -137,14 +127,14 @@ export function useConfigAdmin() {
       try {
         const syncResponse = await fetch('/frontend-api/admin/sync-hero', {
           method: 'POST',
+          credentials: 'omit',
           headers: {
             'Content-Type': 'application/json',
             ...getAuthHeader()
           },
           body: JSON.stringify({
             imageUrl: data.url
-          }),
-          credentials: 'include'
+          })
         });
 
         if (syncResponse.ok) {
@@ -173,18 +163,14 @@ export function useConfigAdmin() {
     setSuccess(null);
 
     try {
-      // Ensure token is also in cookie
-      const token = localStorage.getItem('jwt');
-      document.cookie = `jwt=${token || ''}; path=/; max-age=3600; SameSite=None; Secure=false`;
-
       const response = await fetch('/frontend-api/admin/config', {
         method: 'POST',
+        credentials: 'omit',
         headers: {
           'Content-Type': 'application/json',
           ...getAuthHeader()
         },
-        body: JSON.stringify(configData),
-        credentials: 'include'
+        body: JSON.stringify(configData)
       });
 
       if (!response.ok) {

--- a/frontend/test/admin-config-route.test.ts
+++ b/frontend/test/admin-config-route.test.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { NextRequest } from 'next/server';
+
+const BACKEND_URL = 'http://backend.test';
+const BACKEND_USER_URL = `${BACKEND_URL}/api/users/me`;
+
+type FetchCall = {
+  url: string;
+  authorization?: string;
+  cache?: RequestCache;
+};
+
+const originalCwd = process.cwd();
+const originalFetch = globalThis.fetch;
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+type AdminConfigRoute = typeof import('../src/app/frontend-api/admin/config/route');
+
+async function withRouteWorkspace(testBody: (workspace: string) => Promise<void>) {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'admin-config-route-'));
+  const frontendRoot = path.join(workspaceRoot, 'frontend');
+
+  await mkdir(frontendRoot, { recursive: true });
+  process.chdir(frontendRoot);
+
+  try {
+    await testBody(workspaceRoot);
+  } finally {
+    process.chdir(originalCwd);
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+function installFetchStub(calls: FetchCall[]) {
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = input instanceof Request ? input.url : input.toString();
+    const authorization = getAuthorization(init?.headers);
+    calls.push({ url, authorization, cache: init?.cache });
+
+    if (url !== BACKEND_USER_URL) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    if (authorization === 'Bearer admin-token') {
+      return Response.json({ role: 'admin' });
+    }
+
+    if (authorization === 'Bearer user-token') {
+      return Response.json({ role: 'user' });
+    }
+
+    return new Response('Unauthorized', { status: 401 });
+  };
+}
+
+function getAuthorization(headers: HeadersInit | undefined): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (headers instanceof Headers) {
+    return headers.get('Authorization') ?? headers.get('authorization') ?? undefined;
+  }
+
+  if (Array.isArray(headers)) {
+    return headers.find(([key]) => key.toLowerCase() === 'authorization')?.[1];
+  }
+
+  return headers.Authorization ?? headers.authorization;
+}
+
+function makeRequest(token: string | null, body?: unknown) {
+  const headers = new Headers({ 'content-type': 'application/json' });
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return new NextRequest('http://localhost/frontend-api/admin/config', {
+    method: body === undefined ? 'GET' : 'POST',
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function makeCookieOnlyRequest(token: string, body?: unknown) {
+  return new NextRequest('http://localhost/frontend-api/admin/config', {
+    method: body === undefined ? 'GET' : 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie: `jwt=${token}`,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function configPath(workspaceRoot: string) {
+  return path.join(workspaceRoot, 'frontend', 'public', 'config', 'homepage.json');
+}
+
+async function responseJson(response: Response) {
+  return await response.json() as {
+    success?: boolean;
+    error?: string;
+    config?: Record<string, unknown>;
+  };
+}
+
+async function rejectsCookieOnlyTokenBeforeBackendOrFileAccess(route: AdminConfigRoute) {
+  await withRouteWorkspace(async (workspaceRoot) => {
+    const calls: FetchCall[] = [];
+    installFetchStub(calls);
+
+    const response = await route.GET(makeCookieOnlyRequest('admin-token'));
+    const body = await responseJson(response);
+
+    assert.equal(response.status, 401);
+    assert.match(body.error ?? '', /login/i);
+    assert.equal(existsSync(configPath(workspaceRoot)), false);
+    assert.deepEqual(calls, []);
+  });
+}
+
+async function rejectsNonAdminBearerBeforeFileAccess(route: AdminConfigRoute) {
+  await withRouteWorkspace(async (workspaceRoot) => {
+    const calls: FetchCall[] = [];
+    installFetchStub(calls);
+
+    const response = await route.POST(makeRequest('user-token', { heroImage: { imageUrl: '/x.jpg' } }));
+    const body = await responseJson(response);
+
+    assert.equal(response.status, 403);
+    assert.match(body.error ?? '', /Admin access required/i);
+    assert.equal(existsSync(configPath(workspaceRoot)), false);
+    assert.deepEqual(calls, [{ url: BACKEND_USER_URL, authorization: 'Bearer user-token', cache: 'no-store' }]);
+  });
+}
+
+async function allowsAdminBearerToWriteConfig(route: AdminConfigRoute) {
+  await withRouteWorkspace(async (workspaceRoot) => {
+    const calls: FetchCall[] = [];
+    installFetchStub(calls);
+
+    const response = await route.POST(makeRequest('admin-token', {
+      heroImage: {
+        imageUrl: '/images/home/hero.jpg',
+        description: 'New hero',
+      },
+    }));
+    const body = await responseJson(response);
+    const saved = JSON.parse(await readFile(configPath(workspaceRoot), 'utf-8'));
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(saved.heroImage.description, 'New hero');
+    assert.equal(typeof saved.lastUpdated, 'string');
+    assert.deepEqual(calls, [{ url: BACKEND_USER_URL, authorization: 'Bearer admin-token', cache: 'no-store' }]);
+  });
+}
+
+async function main() {
+  process.env.NEXT_PUBLIC_API_URL = BACKEND_URL;
+  const route = await import('../src/app/frontend-api/admin/config/route');
+
+  try {
+    await rejectsCookieOnlyTokenBeforeBackendOrFileAccess(route);
+    await rejectsNonAdminBearerBeforeFileAccess(route);
+    await allowsAdminBearerToWriteConfig(route);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv('NEXT_PUBLIC_API_URL', originalApiUrl);
+    process.chdir(originalCwd);
+  }
+}
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/test/sync-hero-route.test.ts
+++ b/frontend/test/sync-hero-route.test.ts
@@ -9,6 +9,8 @@ import { POST } from '../src/app/frontend-api/admin/sync-hero/route';
 
 const BACKEND_URL = 'http://backend.test';
 const HERO_URL = 'https://img.munichweekly.art/uploads/hero.jpg';
+const HERO_URL_WITH_FRAGMENT = 'https://img.munichweekly.art/uploads/hero.jpg?variant=admin#browser-only';
+const HERO_CANONICAL_URL = 'https://img.munichweekly.art/uploads/hero.jpg?variant=admin';
 const PRIVATE_URL = 'http://169.254.169.254/latest/meta-data';
 const PRIVATE_IPV6_URL = 'https://[::1]/hero.jpg';
 const PRIVATE_MAPPED_IPV6_URL = 'https://[::ffff:127.0.0.1]/hero.jpg';
@@ -87,7 +89,7 @@ function installFetchStub(calls: FetchCall[]) {
       return new Response('Unauthorized', { status: 401 });
     }
 
-    if (url === HERO_URL) {
+    if (url === HERO_URL || url === HERO_CANONICAL_URL) {
       return new Response(JPEG_BYTES, {
         status: 200,
         headers: {
@@ -164,6 +166,17 @@ function makeRequest(token: string | null, imageUrl?: string) {
   });
 }
 
+function makeCookieOnlyRequest(token: string, imageUrl?: string) {
+  return new NextRequest('http://localhost/frontend-api/admin/sync-hero', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie: `jwt=${token}`,
+    },
+    body: JSON.stringify(imageUrl ? { imageUrl } : {}),
+  });
+}
+
 function frontendHeroPath(workspaceRoot: string) {
   return path.join(workspaceRoot, 'frontend', 'public', 'images', 'home', 'hero.jpg');
 }
@@ -178,6 +191,21 @@ async function rejectsMissingTokenBeforeBackendOrImageFetch() {
     installFetchStub(calls);
 
     const response = await POST(makeRequest(null, HERO_URL));
+    const body = await responseJson(response);
+
+    assert.equal(response.status, 401);
+    assert.match(body.error ?? '', /login/i);
+    assert.equal(existsSync(frontendHeroPath(workspaceRoot)), false);
+    assert.deepEqual(calls, []);
+  });
+}
+
+async function rejectsCookieOnlyTokenBeforeBackendOrImageFetch() {
+  await withRouteWorkspace(async (workspaceRoot) => {
+    const calls: FetchCall[] = [];
+    installFetchStub(calls);
+
+    const response = await POST(makeCookieOnlyRequest('admin-token', HERO_URL));
     const body = await responseJson(response);
 
     assert.equal(response.status, 401);
@@ -326,6 +354,25 @@ async function allowsAdminToSyncTrustedRemoteHero() {
   });
 }
 
+async function allowsAdminToSyncCanonicalTrustedRemoteHero() {
+  await withRouteWorkspace(async (workspaceRoot) => {
+    const calls: FetchCall[] = [];
+    installFetchStub(calls);
+
+    const response = await POST(makeRequest('admin-token', HERO_URL_WITH_FRAGMENT));
+    const body = await responseJson(response);
+    const saved = await readFile(frontendHeroPath(workspaceRoot));
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(body.sourceType, 'remote');
+    assert.deepEqual(saved, JPEG_BYTES);
+    assert.deepEqual(calls.map((call) => call.url), [`${BACKEND_URL}/api/users/me`, HERO_CANONICAL_URL]);
+    assert.equal(calls[1].redirect, 'error');
+    assert.equal(calls[1].cache, 'no-store');
+  });
+}
+
 async function allowsAdminToSyncLocalUploadedHeroByExtension() {
   await withRouteWorkspace(async (workspaceRoot) => {
     const calls: FetchCall[] = [];
@@ -368,6 +415,7 @@ async function main() {
 
   try {
     await rejectsMissingTokenBeforeBackendOrImageFetch();
+    await rejectsCookieOnlyTokenBeforeBackendOrImageFetch();
     await rejectsArbitraryBearerBeforeMutatingHero();
     await rejectsNonAdminUserBeforeFetchingImage();
     await rejectsPrivateRemoteUrlBeforeFetchingIt();
@@ -377,6 +425,7 @@ async function main() {
     await rejectsRemoteNonImageContentType();
     await rejectsOversizedRemoteContentLength();
     await allowsAdminToSyncTrustedRemoteHero();
+    await allowsAdminToSyncCanonicalTrustedRemoteHero();
     await allowsAdminToSyncLocalUploadedHeroByExtension();
     await allowsAdminToSyncDefaultLocalHeroWhenBodyHasNoImageUrl();
   } finally {


### PR DESCRIPTION
## Summary

- require explicit `Authorization: Bearer` JWTs for `/frontend-api/admin/config` and `/frontend-api/admin/sync-hero`
- stop `useConfigAdmin` from writing a `jwt` cookie or sending ambient credentials to admin config/sync routes
- canonicalize remote hero downloads through an allowlisted origin, while preserving HTTPS, private/local host, credential, redirect, size, content-type, and image-signature checks
- add route regression coverage for cookie-only admin requests and canonical hero sync URLs

## Security context

This addresses CodeQL alert #1 (`js/request-forgery`) on `frontend/src/app/frontend-api/admin/sync-hero/route.ts` and tightens the adjacent admin frontend API auth boundary. It intentionally does not handle the remaining backend CodeQL alerts.

Residual risk: `sync-hero` validates URL hostname/literal IP values and uses exact origin allowlists, but it does not perform post-DNS-resolution private IP checks. Operations should keep `HERO_IMAGE_ALLOWED_ORIGINS` limited to trusted public storage/CDN origins.

## Validation

- `cd frontend && npm run test:routes`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `./scripts/check-docs.sh`
- `git diff --check`

Cross-review: subagent review reported no findings.
