### PR TITLE
[codex] Fix backend CodeQL security alerts

### DIFF
--- a/backend/src/main/java/com/munichweekly/backend/controller/FileUploadController.java
+++ b/backend/src/main/java/com/munichweekly/backend/controller/FileUploadController.java
@@ -499,8 +499,7 @@ public class FileUploadController {
             
             // If using LocalStorageService, we need to manually save to a specific location
             if (storageService instanceof LocalStorageService) {
-                // Use special path to save hero image
-                String heroFileUrl = saveHeroImageLocally(file, localStorageService);
+                String heroFileUrl = localStorageService.storeHeroImage(file);
                 
                 if (heroFileUrl != null) {
                     response.put("success", true);
@@ -526,55 +525,18 @@ public class FileUploadController {
         } catch (IllegalArgumentException e) {
             logger.warn("Invalid hero image upload: " + e.getMessage());
             response.put("success", false);
-            response.put("error", e.getMessage());
+            response.put("error", "Hero image upload request is invalid");
             return ResponseEntity.badRequest().body(response);
         } catch (IOException e) {
             logger.error("Hero image upload error: " + e.getMessage(), e);
             response.put("success", false);
-            response.put("error", "Failed to store hero image: " + e.getMessage());
+            response.put("error", "Failed to store hero image");
             return ResponseEntity.internalServerError().body(response);
         } catch (Exception e) {
             logger.error("Unexpected error during hero image upload", e);
             response.put("success", false);
-            response.put("error", "An unexpected error occurred: " + e.getMessage());
+            response.put("error", "Internal server error");
             return ResponseEntity.internalServerError().body(response);
-        }
-    }
-    
-    /**
-     * Save hero image to specific location in local storage
-     */
-    private String saveHeroImageLocally(MultipartFile file, LocalStorageService localService) throws IOException {
-        // Get the root path of uploads directory
-        try {
-            java.lang.reflect.Field rootLocationField = LocalStorageService.class.getDeclaredField("rootLocation");
-            rootLocationField.setAccessible(true);
-            java.nio.file.Path rootLocation = (java.nio.file.Path) rootLocationField.get(localService);
-            
-            // Determine file extension
-            String originalFilename = file.getOriginalFilename();
-            String extension = "jpg"; // Default
-            if (originalFilename != null && originalFilename.contains(".")) {
-                extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
-            }
-            
-            // Save as fixed hero.jpg
-            java.nio.file.Path heroImagePath = rootLocation.resolve("hero." + extension);
-            
-            logger.info("Saving hero image to: " + heroImagePath);
-            
-            // Save file, replace existing file
-            java.nio.file.Files.copy(file.getInputStream(), heroImagePath, 
-                    java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-            
-            logger.info("Hero image saved successfully: " + heroImagePath);
-            
-            // Return accessible URL path
-            return "/uploads/hero." + extension;
-            
-        } catch (Exception e) {
-            logger.error("Failed to save hero image locally: " + e.getMessage(), e);
-            throw new IOException("Failed to save hero image: " + e.getMessage(), e);
         }
     }
 }

--- a/backend/src/main/java/com/munichweekly/backend/controller/PromotionController.java
+++ b/backend/src/main/java/com/munichweekly/backend/controller/PromotionController.java
@@ -2,9 +2,13 @@ package com.munichweekly.backend.controller;
 
 import com.munichweekly.backend.dto.*;
 import com.munichweekly.backend.service.PromotionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -186,32 +190,50 @@ public class PromotionController {
      * 
      * POST /api/promotion/admin/images/{imageId}/upload
      */
-    @PostMapping("/admin/images/{imageId}/upload")
+    @PostMapping(value = "/admin/images/{imageId}/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasAuthority('admin')")
-    public ResponseEntity<String> uploadPromotionImageFile(
+    @Operation(summary = "Upload a promotion image file")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponse(responseCode = "200", description = "Promotion image uploaded")
+    @ApiResponse(responseCode = "400", description = "Upload request is invalid")
+    @ApiResponse(responseCode = "500", description = "Upload failed")
+    public ResponseEntity<FileUploadResponseDTO> uploadPromotionImageFile(
             @PathVariable Long imageId,
             @RequestParam("file") MultipartFile file) {
         try {
             // Validate file type
             if (file.isEmpty()) {
-                return ResponseEntity.badRequest().body("File cannot be empty");
+                return ResponseEntity.badRequest()
+                        .body(new FileUploadResponseDTO(false, "File cannot be empty"));
             }
 
             String contentType = file.getContentType();
             if (contentType == null || (!contentType.startsWith("image/"))) {
-                return ResponseEntity.badRequest().body("File must be image format");
+                return ResponseEntity.badRequest()
+                        .body(new FileUploadResponseDTO(false, "File must be image format"));
             }
 
             // Call service to upload file
             String imageUrl = promotionService.uploadPromotionImageFile(imageId, file);
-            return ResponseEntity.ok(imageUrl);
+            if (imageUrl == null || imageUrl.isBlank()) {
+                logger.error("Promotion image upload returned empty URL for imageId={}", imageId);
+                return ResponseEntity.internalServerError()
+                        .body(new FileUploadResponseDTO(false, "File upload failed"));
+            }
+            return ResponseEntity.ok(new FileUploadResponseDTO(imageUrl));
 
         } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            logger.warn("Invalid promotion image upload for imageId={}: {}", imageId, e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body(new FileUploadResponseDTO(false, "Promotion image upload request is invalid"));
         } catch (IOException e) {
-            return ResponseEntity.internalServerError().body("File upload failed");
+            logger.error("Promotion image upload I/O failure for imageId={}", imageId, e);
+            return ResponseEntity.internalServerError()
+                    .body(new FileUploadResponseDTO(false, "File upload failed"));
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body("Internal server error");
+            logger.error("Unexpected promotion image upload failure for imageId={}", imageId, e);
+            return ResponseEntity.internalServerError()
+                    .body(new FileUploadResponseDTO(false, "Internal server error"));
         }
     }
 
@@ -254,4 +276,4 @@ public class PromotionController {
             return ResponseEntity.internalServerError().build();
         }
     }
-} 
+}

--- a/backend/src/main/java/com/munichweekly/backend/service/AnonymousSubmissionService.java
+++ b/backend/src/main/java/com/munichweekly/backend/service/AnonymousSubmissionService.java
@@ -14,13 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 @Service
 public class AnonymousSubmissionService {
 
     private static final int MAX_DESCRIPTION_LENGTH = 2000;
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+    private static final int MAX_EMAIL_LENGTH = 254;
+    private static final int MAX_EMAIL_LOCAL_PART_LENGTH = 64;
 
     private final IssueRepository issueRepository;
     private final UserRepository userRepository;
@@ -86,9 +86,39 @@ public class AnonymousSubmissionService {
         }
 
         String contactEmail = normalizeOptionalEmail(request.getContactEmail());
-        if (contactEmail != null && !EMAIL_PATTERN.matcher(contactEmail).matches()) {
+        if (contactEmail != null && !isValidContactEmail(contactEmail)) {
             throw new IllegalArgumentException("Contact email must be a valid email address");
         }
+    }
+
+    private boolean isValidContactEmail(String email) {
+        if (email.length() > MAX_EMAIL_LENGTH) {
+            return false;
+        }
+
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 0 || atIndex != email.lastIndexOf('@') || atIndex > MAX_EMAIL_LOCAL_PART_LENGTH) {
+            return false;
+        }
+
+        String localPart = email.substring(0, atIndex);
+        String domain = email.substring(atIndex + 1);
+        int lastDotIndex = domain.lastIndexOf('.');
+        if (localPart.isEmpty() || domain.isEmpty() || lastDotIndex <= 0 || lastDotIndex == domain.length() - 1) {
+            return false;
+        }
+
+        return !containsWhitespaceOrControl(email);
+    }
+
+    private boolean containsWhitespaceOrControl(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (Character.isWhitespace(current) || Character.isISOControl(current)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void validateSubmissionWindow(Issue issue) {

--- a/backend/src/main/java/com/munichweekly/backend/service/LocalStorageService.java
+++ b/backend/src/main/java/com/munichweekly/backend/service/LocalStorageService.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,9 +46,9 @@ public class LocalStorageService implements StorageService {
     @PostConstruct
     public void init() {
         try {
-            rootLocation = Paths.get(uploadsDirectory);
+            rootLocation = Paths.get(uploadsDirectory).toAbsolutePath().normalize();
             Files.createDirectories(rootLocation);
-            logger.info("Local storage initialized at: " + rootLocation.toAbsolutePath());
+            logger.info("Local storage initialized at: " + rootLocation);
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Could not initialize local storage", e);
             throw new RuntimeException("Could not initialize storage", e);
@@ -78,9 +79,11 @@ public class LocalStorageService implements StorageService {
         }
         
         validateFile(file);
+        String safeIssueId = requireSafePathSegment(issueId, "Issue ID");
+        String safeSubmissionId = requireSafePathSegment(submissionId, "Submission ID");
         
         // Create directory structure: uploads/issues/{issueId}/submissions/
-        Path issueDir = rootLocation.resolve("issues").resolve(issueId).resolve("submissions");
+        Path issueDir = resolveUnderRoot("issues", safeIssueId, "submissions");
         Files.createDirectories(issueDir);
         
         // Get file extension
@@ -88,8 +91,8 @@ public class LocalStorageService implements StorageService {
         String extension = getFileExtension(originalFilename);
         
         // Create filename: {submissionId}.{extension}
-        String filename = submissionId + "." + extension;
-        Path destinationFile = issueDir.resolve(filename);
+        String filename = safeSubmissionId + "." + extension;
+        Path destinationFile = resolveUnderRoot("issues", safeIssueId, "submissions", filename);
         
         // **OPTIMIZATION: Extract dimensions from stream before storing**
         ImageDimensions dimensions = null;
@@ -117,8 +120,23 @@ public class LocalStorageService implements StorageService {
         }
         
         // Return relative URL for frontend access
-        String relativePath = "/uploads/issues/" + issueId + "/submissions/" + filename;
+        String relativePath = "/uploads/issues/" + safeIssueId + "/submissions/" + filename;
         return new StorageResult(relativePath, dimensions);
+    }
+
+    public String storeHeroImage(MultipartFile file) throws IOException {
+        if (file == null) {
+            throw new IllegalArgumentException("File cannot be null");
+        }
+
+        validateFile(file);
+        String filename = heroFilenameForContentType(file.getContentType());
+        Path heroImagePath = resolveUnderRoot(filename);
+
+        Files.copy(file.getInputStream(), heroImagePath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        logger.info("Hero image saved successfully: " + heroImagePath);
+
+        return "/uploads/" + filename;
     }
     
     /**
@@ -209,7 +227,7 @@ public class LocalStorageService implements StorageService {
             throw new IllegalArgumentException("File must have a valid extension");
         }
         
-        return filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+        return filename.substring(filename.lastIndexOf(".") + 1).toLowerCase(Locale.ROOT);
     }
     
     /**
@@ -221,21 +239,18 @@ public class LocalStorageService implements StorageService {
     @Override
     public boolean deleteFile(String fileUrl) {
         try {
-            // Extract file name from URL
-            String fileName = fileUrl;
-            if (fileUrl.startsWith("/uploads/")) {
-                fileName = fileUrl.substring("/uploads/".length());
-            }
-            
-            Path filePath = rootLocation.resolve(fileName);
+            Path filePath = resolveUploadUrl(fileUrl);
             logger.info("Attempting to delete file: " + filePath);
             
             if (Files.exists(filePath)) {
                 Files.delete(filePath);
-                logger.info("Deleted file: " + fileName);
+                logger.info("Deleted file: " + filePath);
                 return true;
             }
             logger.warning("File not found for deletion: " + filePath);
+            return false;
+        } catch (IllegalArgumentException e) {
+            logger.warning("Rejected unsafe file deletion path: " + e.getMessage());
             return false;
         } catch (IOException e) {
             logger.log(Level.WARNING, "Failed to delete file: " + fileUrl + " - " + e.getMessage(), e);
@@ -251,15 +266,87 @@ public class LocalStorageService implements StorageService {
      */
     @Override
     public boolean fileExists(String fileUrl) {
-        // Extract file name from URL
-        String fileName = fileUrl;
-        if (fileUrl.startsWith("/uploads/")) {
-            fileName = fileUrl.substring("/uploads/".length());
+        Path filePath;
+        try {
+            filePath = resolveUploadUrl(fileUrl);
+        } catch (IllegalArgumentException e) {
+            logger.warning("Rejected unsafe file lookup path: " + e.getMessage());
+            return false;
         }
-        
-        Path filePath = rootLocation.resolve(fileName);
+
         boolean exists = Files.exists(filePath);
         logger.info("Checking if file exists: " + filePath + " - " + exists);
         return exists;
     }
-} 
+
+    private String heroFilenameForContentType(String contentType) {
+        if ("image/png".equals(contentType)) {
+            return "hero.png";
+        }
+        if ("image/jpeg".equals(contentType)) {
+            return "hero.jpg";
+        }
+        throw new IllegalArgumentException("File type not allowed. Only JPEG and PNG images are supported.");
+    }
+
+    private String requireSafePathSegment(String value, String label) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(label + " cannot be empty");
+        }
+
+        String trimmed = value.trim();
+        if (".".equals(trimmed) || "..".equals(trimmed) || trimmed.length() > 120) {
+            throw new IllegalArgumentException(label + " is invalid");
+        }
+
+        for (int index = 0; index < trimmed.length(); index++) {
+            char current = trimmed.charAt(index);
+            boolean safe = Character.isLetterOrDigit(current)
+                    || current == '-'
+                    || current == '_'
+                    || current == '.';
+            if (!safe) {
+                throw new IllegalArgumentException(label + " contains invalid characters");
+            }
+        }
+
+        return trimmed;
+    }
+
+    private Path resolveUploadUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            throw new IllegalArgumentException("File URL cannot be empty");
+        }
+
+        String relativePath = fileUrl.trim();
+        if (relativePath.startsWith("/uploads/")) {
+            relativePath = relativePath.substring("/uploads/".length());
+        } else if (relativePath.startsWith("uploads/")) {
+            relativePath = relativePath.substring("uploads/".length());
+        }
+
+        if (relativePath.contains("\\") || relativePath.contains("\0") || relativePath.contains("://")) {
+            throw new IllegalArgumentException("File URL is invalid");
+        }
+
+        String[] segments = relativePath.split("/");
+        for (String segment : segments) {
+            requireSafePathSegment(segment, "File URL path segment");
+        }
+
+        return resolveUnderRoot(segments);
+    }
+
+    private Path resolveUnderRoot(String... segments) {
+        Path resolved = rootLocation;
+        for (String segment : segments) {
+            resolved = resolved.resolve(segment);
+        }
+
+        Path normalized = resolved.normalize();
+        if (!normalized.startsWith(rootLocation)) {
+            throw new IllegalArgumentException("File path is outside uploads directory");
+        }
+        return normalized;
+    }
+}

--- a/backend/src/test/java/com/munichweekly/backend/controller/FileUploadControllerAnonymousTest.java
+++ b/backend/src/test/java/com/munichweekly/backend/controller/FileUploadControllerAnonymousTest.java
@@ -222,6 +222,49 @@ class FileUploadControllerAnonymousTest {
         verify(storageService, never()).storeFileWithDimensions(any(), any(), any(), any());
     }
 
+    @Test
+    void localHeroUploadDelegatesToLocalStorageService() throws Exception {
+        LocalStorageService localService = mock(LocalStorageService.class);
+        when(localService.storeHeroImage(any())).thenReturn("/uploads/hero.png");
+        FileUploadController localController = new FileUploadController(
+                localService,
+                new SubmissionUploadService(submissionRepository),
+                r2StorageService,
+                localService,
+                anonymousUploadTokenService
+        );
+
+        ResponseEntity<Map<String, Object>> response = localController.uploadHeroImage(
+                new MockMultipartFile("file", "hero.jpg/../../evil.png", "image/png", "image".getBytes())
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsEntry("url", "/uploads/hero.png");
+        verify(localService).storeHeroImage(any());
+    }
+
+    @Test
+    void localHeroUploadDoesNotExposeStorageExceptionText() throws Exception {
+        LocalStorageService localService = mock(LocalStorageService.class);
+        when(localService.storeHeroImage(any()))
+                .thenThrow(new IllegalArgumentException("<script>alert(1)</script>"));
+        FileUploadController localController = new FileUploadController(
+                localService,
+                new SubmissionUploadService(submissionRepository),
+                r2StorageService,
+                localService,
+                anonymousUploadTokenService
+        );
+
+        ResponseEntity<Map<String, Object>> response = localController.uploadHeroImage(
+                new MockMultipartFile("file", "hero.jpg/../../evil.png", "image/png", "image".getBytes())
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).containsEntry("error", "Hero image upload request is invalid");
+        assertThat(response.getBody().toString()).doesNotContain("<script>");
+    }
+
     private Submission anonymousSubmission() {
         Issue issue = new Issue(
                 "Street Corners",

--- a/backend/src/test/java/com/munichweekly/backend/controller/PromotionControllerTest.java
+++ b/backend/src/test/java/com/munichweekly/backend/controller/PromotionControllerTest.java
@@ -1,0 +1,61 @@
+package com.munichweekly.backend.controller;
+
+import com.munichweekly.backend.dto.FileUploadResponseDTO;
+import com.munichweekly.backend.service.PromotionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PromotionControllerTest {
+
+    private PromotionService promotionService;
+    private PromotionController controller;
+
+    @BeforeEach
+    void setUp() {
+        promotionService = mock(PromotionService.class);
+        controller = new PromotionController(promotionService);
+    }
+
+    @Test
+    void uploadPromotionImageReturnsJsonUploadResponse() throws Exception {
+        MockMultipartFile file = imageFile("promotion.jpg", "image/jpeg");
+        when(promotionService.uploadPromotionImageFile(eq(5L), any()))
+                .thenReturn("/uploads/issues/promotion/submissions/5.jpg");
+
+        ResponseEntity<FileUploadResponseDTO> response = controller.uploadPromotionImageFile(5L, file);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getImageUrl()).isEqualTo("/uploads/issues/promotion/submissions/5.jpg");
+        assertThat(response.getBody().getError()).isNull();
+    }
+
+    @Test
+    void uploadPromotionImageDoesNotExposeServiceExceptionText() throws Exception {
+        MockMultipartFile file = imageFile("promotion.jpg", "image/jpeg");
+        when(promotionService.uploadPromotionImageFile(eq(5L), any()))
+                .thenThrow(new IllegalArgumentException("<script>alert(1)</script>"));
+
+        ResponseEntity<FileUploadResponseDTO> response = controller.uploadPromotionImageFile(5L, file);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isFalse();
+        assertThat(response.getBody().getError()).isEqualTo("Promotion image upload request is invalid");
+        assertThat(response.getBody().getError()).doesNotContain("<script>");
+    }
+
+    private MockMultipartFile imageFile(String filename, String contentType) {
+        return new MockMultipartFile("file", filename, contentType, "image".getBytes());
+    }
+}

--- a/backend/src/test/java/com/munichweekly/backend/service/AnonymousSubmissionServiceTest.java
+++ b/backend/src/test/java/com/munichweekly/backend/service/AnonymousSubmissionServiceTest.java
@@ -137,6 +137,23 @@ class AnonymousSubmissionServiceTest {
         verify(submissionRepository, never()).save(any());
     }
 
+    @Test
+    void rejectsPathologicalContactEmailBeforeCaptchaOrDatabaseAccess() {
+        AnonymousSubmissionRequestDTO request = new AnonymousSubmissionRequestDTO();
+        request.setIssueId(7L);
+        request.setDescription("A quiet street after rain");
+        request.setContactEmail("!@!." + "!.".repeat(5000));
+        request.setCaptchaToken("captcha-token");
+
+        assertThatThrownBy(() -> service.createAnonymousSubmission(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Contact email must be a valid email address");
+
+        verify(captchaVerificationService, never()).verify(any());
+        verify(userRepository, never()).save(any());
+        verify(submissionRepository, never()).save(any());
+    }
+
     private Issue activeIssue() {
         LocalDateTime now = LocalDateTime.now();
         return new Issue(

--- a/backend/src/test/java/com/munichweekly/backend/service/LocalStorageServiceTest.java
+++ b/backend/src/test/java/com/munichweekly/backend/service/LocalStorageServiceTest.java
@@ -1,0 +1,116 @@
+package com.munichweekly.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocalStorageServiceTest {
+
+    @TempDir
+    Path uploadsDirectory;
+
+    private LocalStorageService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LocalStorageService();
+        ReflectionTestUtils.setField(service, "uploadsDirectory", uploadsDirectory.toString());
+        service.init();
+    }
+
+    @Test
+    void storesSubmissionFileUnderUploadRootWithSafeSegments() throws Exception {
+        StorageService.StorageResult result = service.storeFileWithDimensions(
+                imageFile("photo.jpg", "image/jpeg"),
+                "7",
+                "42",
+                "99"
+        );
+
+        assertThat(result.getUrl()).isEqualTo("/uploads/issues/7/submissions/99.jpg");
+        assertThat(Files.exists(uploadsDirectory.resolve("issues/7/submissions/99.jpg"))).isTrue();
+    }
+
+    @Test
+    void rejectsTraversalInIssueIdBeforeWritingFile() {
+        assertThatThrownBy(() -> service.storeFileWithDimensions(
+                imageFile("photo.jpg", "image/jpeg"),
+                "../outside",
+                "42",
+                "99"
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Issue ID");
+
+        assertThat(Files.exists(uploadsDirectory.resolve("outside"))).isFalse();
+    }
+
+    @Test
+    void rejectsTraversalInSubmissionIdBeforeWritingFile() {
+        assertThatThrownBy(() -> service.storeFileWithDimensions(
+                imageFile("photo.jpg", "image/jpeg"),
+                "7",
+                "42",
+                "../outside"
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Submission ID");
+
+        assertThat(Files.exists(uploadsDirectory.resolve("issues/7/submissions/outside.jpg"))).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/uploads/../secret.txt",
+            "/uploads/%2fsecret.txt",
+            "/uploads/%5csecret.txt",
+            "/uploads/issues\\7\\secret.jpg",
+            "/tmp/secret.txt",
+            "C:/secret.txt",
+            "/uploads/issues//secret.jpg",
+            "/uploads/./secret.txt",
+            "/uploads/issues/../secret.txt",
+            "/uploads/issues/\0/secret.jpg"
+    })
+    void fileLookupAndDeleteRejectUnsafeUrls(String fileUrl) {
+        assertThat(service.fileExists(fileUrl)).isFalse();
+        assertThat(service.deleteFile(fileUrl)).isFalse();
+    }
+
+    @Test
+    void fileLookupAndDeleteAllowValidNestedUploadUrls() throws Exception {
+        StorageService.StorageResult result = service.storeFileWithDimensions(
+                imageFile("photo.jpg", "image/jpeg"),
+                "7",
+                "42",
+                "99"
+        );
+
+        assertThat(service.fileExists(result.getUrl())).isTrue();
+        assertThat(service.deleteFile(result.getUrl())).isTrue();
+        assertThat(service.fileExists(result.getUrl())).isFalse();
+    }
+
+    @Test
+    void heroImageUsesFixedFilenameFromContentType() throws Exception {
+        String url = service.storeHeroImage(imageFile("hero.jpg/../../evil.png", "image/png"));
+
+        assertThat(url).isEqualTo("/uploads/hero.png");
+        assertThat(Files.exists(uploadsDirectory.resolve("hero.png"))).isTrue();
+        assertThat(Files.exists(uploadsDirectory.resolve("evil.png"))).isFalse();
+    }
+
+    private MockMultipartFile imageFile(String filename, String contentType) {
+        return new MockMultipartFile("file", filename, contentType, "image".getBytes());
+    }
+}

--- a/docs/api.json
+++ b/docs/api.json
@@ -2719,7 +2719,7 @@
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
                 "properties": {
                   "file": {
@@ -2740,13 +2740,39 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/FileUploadResponseDTO"
                 }
               }
             },
-            "description": "OK"
+            "description": "Promotion image uploaded"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponseDTO"
+                }
+              }
+            },
+            "description": "Upload request is invalid"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponseDTO"
+                }
+              }
+            },
+            "description": "Upload failed"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Upload a promotion image file",
         "tags": [
           "promotion-controller"
         ]

--- a/frontend/src/api/promotion/admin.ts
+++ b/frontend/src/api/promotion/admin.ts
@@ -6,6 +6,12 @@
 import { fetchAPI } from '../http';
 import { PromotionConfig, PromotionImage } from '@/types/promotion';
 
+type PromotionUploadResponse = {
+  success?: boolean;
+  imageUrl?: string;
+  error?: string;
+};
+
 /**
  * Get all promotion configurations for admin
  * Admin endpoint - requires admin authentication
@@ -92,12 +98,20 @@ export const uploadPromotionImageFile = async (imageId: number, file: File): Pro
     body: formData,
   });
 
+  const contentType = response.headers.get('content-type') ?? '';
+  const payload: PromotionUploadResponse = contentType.includes('application/json')
+    ? await response.json()
+    : { imageUrl: await response.text() };
+
   if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(errorText || `Upload failed: ${response.status}`);
+    throw new Error(payload.error || `Upload failed: ${response.status}`);
   }
 
-  return await response.text();
+  if (!payload.imageUrl) {
+    throw new Error('Upload response did not include an image URL');
+  }
+
+  return payload.imageUrl;
 };
 
 /**
@@ -119,4 +133,4 @@ export const deletePromotionConfig = async (configId: number): Promise<void> => 
   return await fetchAPI<void>(`/api/promotion/admin/config/${configId}`, {
     method: 'DELETE',
   });
-}; 
+};


### PR DESCRIPTION
## Summary
- Harden promotion image upload responses so user-influenced values are returned as JSON DTOs and service exception text is not exposed.
- Replace anonymous submission email regex with bounded linear validation.
- Constrain local storage paths under the upload root and move hero image writes into LocalStorageService with fixed filenames.
- Update frontend promotion upload parsing and regenerate docs/api.json.

## Code Scanning
Addresses GitHub CodeQL alerts #3, #4, #5, #6, #7, and #8. Alert #2 (CSRF policy) is intentionally out of scope.

## Validation
- ./gradlew test --tests '*AnonymousSubmissionServiceTest' --tests '*LocalStorageServiceTest' --tests '*PromotionControllerTest' --tests '*FileUploadControllerAnonymousTest'\n- ./gradlew test\n- npx tsc --noEmit\n- npm run lint\n- npm run build\n- ./scripts/check-docs.sh\n- git diff --check\n\n## Review\n- Subagent review: no findings, ready to PR.