### PR TITLE
[codex] Add explicit CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '37 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - java-kotlin
+          - javascript-typescript
+          - python
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Initialize CodeQL
+        if: matrix.language != 'java-kotlin'
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Initialize CodeQL for Java and Kotlin
+        if: matrix.language == 'java-kotlin'
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -118,6 +118,19 @@ To test the live alert destination, start the template without the temporary
 sudo systemctl start 'munich-weekly-alert@manual-test.service'
 ```
 
+## Repository Security Scanning
+
+CodeQL code scanning is managed by the explicit GitHub Actions workflow at
+`.github/workflows/codeql.yml`. It scans the same language categories GitHub
+default setup previously reported for this repository: Actions, Java/Kotlin,
+JavaScript/TypeScript, and Python.
+
+Keep GitHub CodeQL default setup disabled after the explicit workflow is active.
+Running both default setup and an advanced workflow can suppress the workflow
+uploads or leave pull requests with neutral "configurations not found" code
+scanning checks. If that happens, check the repository's Code Security settings
+and confirm that CodeQL is using the workflow file rather than default setup.
+
 ## Weekly Maintenance Review
 
 Once per week:


### PR DESCRIPTION
## Summary
- add an explicit CodeQL workflow for Actions, Java/Kotlin, JavaScript/TypeScript, and Python
- preserve the language categories that GitHub default setup reported so pull-request code-scanning comparisons have matching configurations
- document that GitHub CodeQL default setup should be disabled after the workflow is active

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codeql.yml'); puts 'yaml ok'"\n- ./scripts/check-docs.sh\n- git diff --check\n\n## Operations note\nGitHub currently reports CodeQL default setup as configured. After this PR is merged, switch the repository CodeQL configuration from default setup to the workflow file; otherwise default setup can continue to suppress advanced workflow uploads or show neutral configuration-mismatch checks.