### PR TITLE
[codex] Use CodeQL v4 action tag

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,18 +36,18 @@ jobs:
 
       - name: Initialize CodeQL
         if: matrix.language != 'java-kotlin'
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Initialize CodeQL for Java and Kotlin
         if: matrix.language == 'java-kotlin'
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -125,6 +125,11 @@ CodeQL code scanning is managed by the explicit GitHub Actions workflow at
 default setup previously reported for this repository: Actions, Java/Kotlin,
 JavaScript/TypeScript, and Python.
 
+The CodeQL action uses the `v4` major-version tag instead of a pinned commit SHA
+so advanced setup continues to receive GitHub's CodeQL action, CLI, and query
+updates within that supported major line. Other CI actions can remain pinned by
+commit SHA.
+
 Keep GitHub CodeQL default setup disabled after the explicit workflow is active.
 Running both default setup and an advanced workflow can suppress the workflow
 uploads or leave pull requests with neutral "configurations not found" code


### PR DESCRIPTION
## Summary
- switch CodeQL init/analyze steps from a pinned commit SHA to the `v4` major tag
- document the CodeQL exception so advanced setup receives CodeQL action, CLI, and query updates within v4

## Validation
- YAML parse check passed
- `./scripts/check-docs.sh` passed
- `git diff --check` passed

## Operations note
This keeps other CI actions pinned while allowing CodeQL advanced setup to follow the supported v4 release line. CodeQL default setup remains disabled.