### PR TITLE
[codex] Enable CSRF protection for vote mutations

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,18 +36,18 @@ jobs:
 
       - name: Initialize CodeQL
         if: matrix.language != 'java-kotlin'
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Initialize CodeQL for Java and Kotlin
         if: matrix.language == 'java-kotlin'
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}

--- a/backend/src/main/java/com/munichweekly/backend/controller/CsrfController.java
+++ b/backend/src/main/java/com/munichweekly/backend/controller/CsrfController.java
@@ -1,0 +1,34 @@
+package com.munichweekly.backend.controller;
+
+import com.munichweekly.backend.dto.CsrfTokenResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for browser CSRF token bootstrapping.
+ */
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Security", description = "Browser security token helpers")
+public class CsrfController {
+
+    @Operation(
+            summary = "Get CSRF token",
+            description = "Issues a CSRF token for browser clients that call cookie-backed mutation endpoints."
+    )
+    @ApiResponse(responseCode = "200", description = "CSRF token issued")
+    @GetMapping("/csrf")
+    public CsrfTokenResponseDTO getCsrfToken(@Parameter(hidden = true) CsrfToken csrfToken) {
+        return new CsrfTokenResponseDTO(
+                csrfToken.getHeaderName(),
+                csrfToken.getParameterName(),
+                csrfToken.getToken()
+        );
+    }
+}

--- a/backend/src/main/java/com/munichweekly/backend/controller/VoteController.java
+++ b/backend/src/main/java/com/munichweekly/backend/controller/VoteController.java
@@ -9,6 +9,8 @@ import com.munichweekly.backend.security.CurrentUserUtil;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +34,9 @@ import java.util.Arrays;
 @Tag(name = "Votes", description = "Vote submission and vote status endpoints")
 public class VoteController {
     private static final Logger logger = LoggerFactory.getLogger(VoteController.class);
+    private static final String CSRF_HEADER_DESCRIPTION =
+            "Required for browser clients using cookie-backed anonymous voting. "
+                    + "Bearer-authenticated API clients are exempt.";
 
     private final VoteService voteService;
     private final AnonymousVoteIdentityService anonymousVoteIdentityService;
@@ -54,6 +59,23 @@ public class VoteController {
      * Returns the vote object and current vote count.
      */
     @Description("Submit a vote for a submission. Uses userId for authenticated users and a signed anonymous vote cookie for anonymous users.")
+    @Operation(
+            summary = "Submit a vote",
+            description = "Creates a vote for the current authenticated user or anonymous visitor.",
+            parameters = {
+                    @Parameter(
+                            name = "X-XSRF-TOKEN",
+                            in = ParameterIn.HEADER,
+                            required = false,
+                            schema = @Schema(type = "string"),
+                            description = CSRF_HEADER_DESCRIPTION
+                    )
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Vote created"),
+            @ApiResponse(responseCode = "403", description = "Missing or invalid CSRF token for cookie-backed vote mutation")
+    })
     @PostMapping
     public ResponseEntity<?> vote(
             @RequestParam Long submissionId,
@@ -275,6 +297,31 @@ public class VoteController {
      * Returns success status and updated vote count.
      */
     @Description("Cancel a vote for a submission. Uses userId for authenticated users and a signed anonymous vote cookie for anonymous users.")
+    @Operation(
+            summary = "Cancel a vote",
+            description = "Cancels a vote for the current authenticated user or anonymous visitor.",
+            parameters = {
+                    @Parameter(
+                            name = "X-XSRF-TOKEN",
+                            in = ParameterIn.HEADER,
+                            required = false,
+                            schema = @Schema(type = "string"),
+                            description = CSRF_HEADER_DESCRIPTION
+                    )
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Vote cancellation processed"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Vote cannot be cancelled",
+                    content = @Content(
+                            mediaType = "text/plain",
+                            schema = @Schema(implementation = String.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "403", description = "Missing or invalid CSRF token for cookie-backed vote mutation")
+    })
     @DeleteMapping
     public ResponseEntity<?> cancelVote(
             @RequestParam Long submissionId,

--- a/backend/src/main/java/com/munichweekly/backend/dto/CsrfTokenResponseDTO.java
+++ b/backend/src/main/java/com/munichweekly/backend/dto/CsrfTokenResponseDTO.java
@@ -1,0 +1,43 @@
+package com.munichweekly.backend.dto;
+
+/**
+ * DTO for exposing the CSRF token header contract to browser clients.
+ */
+public class CsrfTokenResponseDTO {
+    private String headerName;
+    private String parameterName;
+    private String token;
+
+    public CsrfTokenResponseDTO() {
+    }
+
+    public CsrfTokenResponseDTO(String headerName, String parameterName, String token) {
+        this.headerName = headerName;
+        this.parameterName = parameterName;
+        this.token = token;
+    }
+
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    public void setHeaderName(String headerName) {
+        this.headerName = headerName;
+    }
+
+    public String getParameterName() {
+        return parameterName;
+    }
+
+    public void setParameterName(String parameterName) {
+        this.parameterName = parameterName;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/backend/src/main/java/com/munichweekly/backend/security/JwtUtil.java
+++ b/backend/src/main/java/com/munichweekly/backend/security/JwtUtil.java
@@ -53,7 +53,7 @@ public class JwtUtil {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (JwtException e) {
-            throw new RuntimeException("Invalid JWT token");
+            throw new JwtException("Invalid JWT token", e);
         }
     }
 
@@ -61,7 +61,11 @@ public class JwtUtil {
      * Extract user ID from token.
      */
     public Long extractUserId(String token) {
-        return Long.parseLong(parseToken(token).getSubject());
+        try {
+            return Long.parseLong(parseToken(token).getSubject());
+        } catch (NumberFormatException e) {
+            throw new JwtException("Invalid JWT subject", e);
+        }
     }
 
     @PostConstruct

--- a/backend/src/main/java/com/munichweekly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/munichweekly/backend/security/SecurityConfig.java
@@ -1,15 +1,19 @@
 package com.munichweekly.backend.security;
 
 import com.munichweekly.backend.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 
@@ -20,6 +24,8 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private static final String VOTES_PATH = "/api/votes";
 
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
@@ -43,7 +49,10 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-                .csrf(AbstractHttpConfigurer::disable) // Disable CSRF for API use
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(new CookieCsrfTokenRepository())
+                        .requireCsrfProtectionMatcher(SecurityConfig::requiresCsrfProtection)
+                )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
                         .accessDeniedHandler(new CustomAccessDeniedHandler())
@@ -54,6 +63,9 @@ public class SecurityConfig {
 
                         // Generated API documentation
                         .requestMatchers("/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
+
+                        // Browser CSRF token helper
+                        .requestMatchers(HttpMethod.GET, "/api/csrf").permitAll()
                         
                         // Authentication endpoints
                         .requestMatchers("/api/auth/**").permitAll()  // Login etc. allowed
@@ -128,10 +140,41 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtUtil, userRepository),
-                        UsernamePasswordAuthenticationFilter.class
+                        CsrfFilter.class
                 );
 
         return http.build();
+    }
+
+    static boolean requiresCsrfProtection(HttpServletRequest request) {
+        String method = request.getMethod();
+        String path = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (!contextPath.isEmpty() && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+        path = removePathParameters(path);
+        return VOTES_PATH.equals(path)
+                && (HttpMethod.POST.name().equals(method) || HttpMethod.DELETE.name().equals(method))
+                && !hasAuthenticatedUser();
+    }
+
+    private static String removePathParameters(String path) {
+        String[] segments = path.split("/", -1);
+        for (int i = 0; i < segments.length; i++) {
+            int pathParameterStart = segments[i].indexOf(';');
+            if (pathParameterStart >= 0) {
+                segments[i] = segments[i].substring(0, pathParameterStart);
+            }
+        }
+        return String.join("/", segments);
+    }
+
+    private static boolean hasAuthenticatedUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null
+                && authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken);
     }
 
     @Bean

--- a/backend/src/test/java/com/munichweekly/backend/security/JwtUtilTest.java
+++ b/backend/src/test/java/com/munichweekly/backend/security/JwtUtilTest.java
@@ -1,7 +1,13 @@
 package com.munichweekly.backend.security;
 
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Key;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,6 +24,31 @@ class JwtUtilTest {
         String token = jwtUtil.generateToken(42L);
 
         assertThat(jwtUtil.extractUserId(token)).isEqualTo(42L);
+    }
+
+    @Test
+    void invalidTokenRaisesJwtException() {
+        JwtUtil jwtUtil = jwtUtilWithSecret(VALID_TEST_SECRET);
+
+        assertThatThrownBy(() -> jwtUtil.extractUserId("not-a-jwt"))
+                .isInstanceOf(JwtException.class)
+                .hasMessageContaining("Invalid JWT token");
+    }
+
+    @Test
+    void nonNumericSubjectRaisesJwtException() {
+        JwtUtil jwtUtil = jwtUtilWithSecret(VALID_TEST_SECRET);
+        Key key = (Key) ReflectionTestUtils.getField(jwtUtil, "key");
+        String token = Jwts.builder()
+                .setSubject("not-a-user-id")
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 3600000L))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThatThrownBy(() -> jwtUtil.extractUserId(token))
+                .isInstanceOf(JwtException.class)
+                .hasMessageContaining("Invalid JWT subject");
     }
 
     @Test

--- a/backend/src/test/java/com/munichweekly/backend/security/SecurityConfigCsrfTest.java
+++ b/backend/src/test/java/com/munichweekly/backend/security/SecurityConfigCsrfTest.java
@@ -1,0 +1,213 @@
+package com.munichweekly.backend.security;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.munichweekly.backend.controller.CsrfController;
+import com.munichweekly.backend.model.User;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {
+        CsrfController.class,
+        SecurityConfigCsrfTest.PublicVoteController.class
+})
+@Import({
+        SecurityConfig.class,
+        SecurityConfigCsrfTest.CsrfTestControllers.class
+})
+class SecurityConfigCsrfTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private com.munichweekly.backend.repository.UserRepository userRepository;
+
+    @TestConfiguration
+    static class CsrfTestControllers {
+        @Bean
+        PublicVoteController publicVoteController() {
+            return new PublicVoteController();
+        }
+    }
+
+    @Test
+    void cookieBackedVoteMutationWithoutCsrfTokenIsRejected() throws Exception {
+        mockMvc.perform(post("/api/votes").param("submissionId", "1"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void cookieBackedCancelVoteMutationWithoutCsrfTokenIsRejected() throws Exception {
+        mockMvc.perform(delete("/api/votes").param("submissionId", "1"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void csrfMatcherNormalizesPathParametersBeforeMatchingVoteMutations() {
+        SecurityContextHolder.clearContext();
+        try {
+            assertThat(SecurityConfig.requiresCsrfProtection(new MockHttpServletRequest("POST", "/api/votes;source=gallery")))
+                    .isTrue();
+            assertThat(SecurityConfig.requiresCsrfProtection(new MockHttpServletRequest("DELETE", "/api/votes;source=gallery")))
+                    .isTrue();
+
+            MockHttpServletRequest requestWithContextPath =
+                    new MockHttpServletRequest("POST", "/weekly/api/votes;source=gallery");
+            requestWithContextPath.setContextPath("/weekly");
+            assertThat(SecurityConfig.requiresCsrfProtection(requestWithContextPath)).isTrue();
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Test
+    void authenticatedBearerVoteMutationWithoutCsrfTokenRemainsAllowed() throws Exception {
+        stubAuthenticatedBearerToken();
+
+        mockMvc.perform(post("/api/votes")
+                        .param("submissionId", "1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void authenticatedBearerCancelVoteMutationWithoutCsrfTokenRemainsAllowed() throws Exception {
+        stubAuthenticatedBearerToken();
+
+        mockMvc.perform(delete("/api/votes")
+                        .param("submissionId", "1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void invalidBearerVoteMutationWithoutCsrfTokenIsRejected() throws Exception {
+        when(jwtUtil.extractUserId("bad-token")).thenThrow(new JwtException("bad token"));
+
+        mockMvc.perform(post("/api/votes")
+                        .param("submissionId", "1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer bad-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void voteReadEndpointsRemainCsrfFree() throws Exception {
+        mockMvc.perform(get("/api/votes/check").param("submissionId", "1"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/votes/check-batch").param("submissionIds", "1,2"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void unrelatedUnsafeApiRequestWithoutCsrfTokenRemainsAllowed() throws Exception {
+        mockMvc.perform(post("/api/auth/csrf-free-test"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void csrfEndpointIssuesTokenThatAuthorizesCookieBackedVoteMutations() throws Exception {
+        MvcResult csrfResult = mockMvc.perform(get("/api/csrf"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("XSRF-TOKEN"))
+                .andExpect(cookie().httpOnly("XSRF-TOKEN", true))
+                .andExpect(jsonPath("$.headerName").value("X-XSRF-TOKEN"))
+                .andExpect(jsonPath("$.parameterName").value("_csrf"))
+                .andExpect(jsonPath("$.token").isString())
+                .andReturn();
+
+        Map<String, String> tokenResponse = objectMapper.readValue(
+                csrfResult.getResponse().getContentAsByteArray(),
+                new TypeReference<>() {
+                }
+        );
+        Cookie csrfCookie = csrfResult.getResponse().getCookie("XSRF-TOKEN");
+
+        assertThat(csrfCookie).isNotNull();
+
+        mockMvc.perform(post("/api/votes")
+                        .param("submissionId", "1")
+                        .cookie(csrfCookie)
+                        .header(tokenResponse.get("headerName"), tokenResponse.get("token")))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/votes")
+                        .param("submissionId", "1")
+                        .cookie(csrfCookie)
+                        .header(tokenResponse.get("headerName"), tokenResponse.get("token")))
+                .andExpect(status().isOk());
+    }
+
+    private void stubAuthenticatedBearerToken() {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(7L);
+        when(user.getRole()).thenReturn("user");
+        when(user.getIsBanned()).thenReturn(false);
+        when(jwtUtil.extractUserId("user-token")).thenReturn(7L);
+        when(userRepository.findById(7L)).thenReturn(Optional.of(user));
+    }
+
+    @RestController
+    public static class PublicVoteController {
+        @PostMapping("/api/votes")
+        Map<String, Boolean> vote() {
+            return Map.of("accepted", true);
+        }
+
+        @DeleteMapping("/api/votes")
+        Map<String, Boolean> cancelVote() {
+            return Map.of("accepted", true);
+        }
+
+        @GetMapping("/api/votes/check")
+        Map<String, Boolean> checkVote() {
+            return Map.of("voted", false);
+        }
+
+        @GetMapping("/api/votes/check-batch")
+        Map<String, Object> checkVotesBatch() {
+            return Map.of("statuses", Map.of(), "totalChecked", 0);
+        }
+
+        @PostMapping("/api/auth/csrf-free-test")
+        Map<String, Boolean> unrelatedMutation() {
+            return Map.of("accepted", true);
+        }
+    }
+
+}

--- a/docs/api.json
+++ b/docs/api.json
@@ -115,6 +115,20 @@
         ],
         "type": "object"
       },
+      "CsrfTokenResponseDTO": {
+        "properties": {
+          "headerName": {
+            "type": "string"
+          },
+          "parameterName": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "EmailLoginRequestDTO": {
         "properties": {
           "email": {
@@ -1497,6 +1511,28 @@
         "summary": "Reset password",
         "tags": [
           "Authentication"
+        ]
+      }
+    },
+    "/api/csrf": {
+      "get": {
+        "description": "Issues a CSRF token for browser clients that call cookie-backed mutation endpoints.",
+        "operationId": "getCsrfToken",
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/CsrfTokenResponseDTO"
+                }
+              }
+            },
+            "description": "CSRF token issued"
+          }
+        },
+        "summary": "Get CSRF token",
+        "tags": [
+          "Security"
         ]
       }
     },
@@ -3592,8 +3628,17 @@
     },
     "/api/votes": {
       "delete": {
+        "description": "Cancels a vote for the current authenticated user or anonymous visitor.",
         "operationId": "cancelVote",
         "parameters": [
+          {
+            "description": "Required for browser clients using cookie-backed anonymous voting. Bearer-authenticated API clients are exempt.",
+            "in": "header",
+            "name": "X-XSRF-TOKEN",
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "in": "query",
             "name": "submissionId",
@@ -3629,16 +3674,46 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Vote cancellation processed"
+          },
+          "400": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Vote cannot be cancelled"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Missing or invalid CSRF token for cookie-backed vote mutation"
           }
         },
+        "summary": "Cancel a vote",
         "tags": [
           "Votes"
         ]
       },
       "post": {
+        "description": "Creates a vote for the current authenticated user or anonymous visitor.",
         "operationId": "vote",
         "parameters": [
+          {
+            "description": "Required for browser clients using cookie-backed anonymous voting. Bearer-authenticated API clients are exempt.",
+            "in": "header",
+            "name": "X-XSRF-TOKEN",
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "in": "query",
             "name": "submissionId",
@@ -3674,9 +3749,20 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Vote created"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Missing or invalid CSRF token for cookie-backed vote mutation"
           }
         },
+        "summary": "Submit a vote",
         "tags": [
           "Votes"
         ]
@@ -3826,6 +3912,10 @@
     {
       "description": "Login, registration, and password reset",
       "name": "Authentication"
+    },
+    {
+      "description": "Browser security token helpers",
+      "name": "Security"
     },
     {
       "description": "Vote submission and vote status endpoints",

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -131,6 +131,13 @@ Voting requests include cookies, and the backend either verifies the signed
 cookie, migrates an existing legacy `visitorId` once, or issues a new random
 anonymous subject.
 
+Browser vote mutations are CSRF-protected because `mw_vote_anon` is an ambient
+cookie. The frontend obtains a token from `GET /api/csrf` and sends the returned
+header on `POST /api/votes` and `DELETE /api/votes`. The accompanying
+`XSRF-TOKEN` cookie is managed by Spring Security and is not a frontend API;
+clients should use the response body token from `/api/csrf` rather than reading
+the cookie directly.
+
 Legacy compatibility is intentionally narrow: if a valid `mw_vote_anon` cookie
 exists, the backend ignores any changed `visitorId` cookie. If `mw_vote_anon` is
 missing and a legacy `visitorId` exists, the backend signs that value into
@@ -173,6 +180,10 @@ and method-level `@PreAuthorize` annotations. Do not maintain public/protected
 endpoint inventories by hand in Markdown; use [API Reference](./api.md), the
 generated [api.json](./api.json), and the backend security config as the current
 facts.
+
+Spring CSRF protection is enabled for cookie-backed vote mutations. JWT-protected
+API calls continue to use explicit `Authorization: Bearer ...` headers rather
+than browser-ambient authentication cookies.
 
 ### 5.2. Error Handling
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -125,6 +125,11 @@ CodeQL code scanning is managed by the explicit GitHub Actions workflow at
 default setup previously reported for this repository: Actions, Java/Kotlin,
 JavaScript/TypeScript, and Python.
 
+The CodeQL action uses the `v4` major-version tag instead of a pinned commit SHA
+so advanced setup continues to receive GitHub's CodeQL action, CLI, and query
+updates within that supported major line. Other CI actions can remain pinned by
+commit SHA.
+
 Keep GitHub CodeQL default setup disabled after the explicit workflow is active.
 Running both default setup and an advanced workflow can suppress the workflow
 uploads or leave pull requests with neutral "configurations not found" code

--- a/docs/security-summary.md
+++ b/docs/security-summary.md
@@ -30,6 +30,7 @@ Use [Authentication & Security](./auth.md) for implementation details,
 - **Purpose**: Enable anonymous voting without user registration
 - **Privacy**: No personal data collection for anonymous users
 - **Constraint**: One vote per signed anonymous subject per submission, with broad IP-based throttles for excessive token issuance or repeated anonymous vote attempts
+- **CSRF**: Browser vote and cancel-vote mutations require the response body token from `GET /api/csrf`
 
 ### User Roles & Permissions
 - **User Role**: Basic functionality (vote, submit, manage own content)
@@ -51,6 +52,7 @@ Use [Authentication & Security](./auth.md) for implementation details,
 ✅ **Privacy-Compliant Anonymous Voting**
 - GDPR-compliant visitor tracking
 - Backend-signed HttpOnly anonymous vote identity
+- CSRF token required for cookie-backed vote mutations
 - Transparent data handling policies
 
 ✅ **Comprehensive Role-Based Access Control**

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -37,6 +37,12 @@ export type FetchAPIOptions = RequestInit & {
 
 const DEFAULT_TIMEOUT_MS = 15000;
 
+type CsrfTokenResponse = {
+  headerName: string;
+  parameterName: string;
+  token: string;
+};
+
 const fetchWithTimeout = async (
   url: string,
   options: RequestInit = {},
@@ -73,6 +79,51 @@ function flattenHeaders(init?: HeadersInit): Record<string, string> {
     Object.assign(out, init);
   }
   return out;
+}
+
+function isCsrfTokenResponse(value: unknown): value is CsrfTokenResponse {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.headerName === "string" &&
+    candidate.headerName.length > 0 &&
+    typeof candidate.parameterName === "string" &&
+    candidate.parameterName.length > 0 &&
+    typeof candidate.token === "string" &&
+    candidate.token.length > 0
+  );
+}
+
+export async function getCsrfHeader(): Promise<Record<string, string>> {
+  const response = await fetchWithTimeout(
+    "/api/csrf",
+    {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+      },
+    },
+    DEFAULT_TIMEOUT_MS
+  );
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(parseApiErrorMessage(responseText, response));
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(responseText) as unknown;
+  } catch {
+    throw new Error("CSRF token response was not valid JSON");
+  }
+
+  if (!isCsrfTokenResponse(parsed)) {
+    throw new Error("CSRF token response was missing required fields");
+  }
+
+  return { [parsed.headerName]: parsed.token };
 }
 
 /**

--- a/frontend/src/api/votes/index.ts
+++ b/frontend/src/api/votes/index.ts
@@ -2,7 +2,7 @@
  * Voting-related API module
  * Provides voting functionality and vote status checking
  */
-import { fetchAPI } from "../http";
+import { fetchAPI, getCsrfHeader } from "../http";
 
 interface VoteResponse {
   vote: { id: number; submissionId: number };
@@ -28,10 +28,12 @@ interface BatchVoteStatusResponse {
 export const submitVote = async (submissionId: number): Promise<VoteResponse> => {
   const url = new URL("/api/votes", window.location.origin);
   url.searchParams.append("submissionId", submissionId.toString());
+  const csrfHeader = await getCsrfHeader();
   
   return fetchAPI<VoteResponse>(url.toString(), {
     method: "POST",
     credentials: "include",
+    headers: csrfHeader,
   });
 };
 
@@ -84,9 +86,11 @@ export const checkBatchVoteStatus = async (submissionIds: number[]): Promise<Bat
 export const cancelVote = async (submissionId: number): Promise<CancelVoteResponse> => {
   const url = new URL("/api/votes", window.location.origin);
   url.searchParams.append("submissionId", submissionId.toString());
+  const csrfHeader = await getCsrfHeader();
   
   return fetchAPI<CancelVoteResponse>(url.toString(), {
     method: "DELETE",
     credentials: "include",
+    headers: csrfHeader,
   });
 };


### PR DESCRIPTION
## Summary
- Enable Spring CSRF protection for cookie-backed anonymous vote mutations.
- Add `GET /api/csrf` and wire frontend vote/cancel calls to send the returned CSRF header.
- Keep authenticated Bearer API clients compatible by exempting only requests with an authenticated security context.
- Harden JWT invalid-token handling and refresh OpenAPI/security docs.

## Root Cause
CodeQL flagged globally disabled Spring CSRF. Anonymous voting uses backend-managed cookies, so browser vote mutations need CSRF protection while non-cookie Bearer API calls must continue to work.

## Validation
- `./gradlew test --rerun-tasks`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `./scripts/check-docs.sh`
- `git diff --check`
- no matches for disabled CSRF patterns in backend source